### PR TITLE
[COOK-1356] Adding mod_status attribute for ExtendedStatus, defaults to 'off'

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,6 +113,9 @@ default['apache']['traceenable'] = "On"
 # mod_auth_openids
 default['apache']['allowed_openids'] = Array.new
 
+# mod_status ExtendedStatus, set to 'true' to enable
+default['apache']['ext_status'] = false
+
 # Prefork Attributes
 default['apache']['prefork']['startservers'] = 16
 default['apache']['prefork']['minspareservers'] = 16

--- a/templates/default/mods/status.conf.erb
+++ b/templates/default/mods/status.conf.erb
@@ -12,5 +12,15 @@
     Allow from localhost ip6-localhost
 #    Allow from .example.com
 </Location>
-
+#
+# ExtendedStatus controls whether Apache will generate "full" status
+# information (ExtendedStatus On) or just basic information (ExtendedStatus
+# Off) when the "server-status" handler is called. The default is Off.
+#
+<% if node['apache']['ext_status'] %>
+ExtendedStatus On
+<% else -%>
+ExtendedStatus Off
+<% end -%>
+#
 </IfModule>


### PR DESCRIPTION
Related ticket URL: http://tickets.opscode.com/browse/COOK-1356
