### PR TITLE
mod_dav_svn recipe: re-include authz_svn module on Ubuntu 12.04

### DIFF
--- a/recipes/mod_dav_svn.rb
+++ b/recipes/mod_dav_svn.rb
@@ -27,3 +27,8 @@ package "libapache2-svn" do
 end
 
 apache_module "dav_svn"
+
+# In Ubuntu 12.04 authz_svn was moved from dav_svn to its own module
+if node[:platform] = 'ubuntu' && node[:platform_version].to_f >= 12.04
+  apache_module "authz_svn"
+end


### PR DESCRIPTION
Prior to Ubuntu 12.04 the libapache2-svn package dav_svn module loader explicitly loaded authz_svn as well. In 12.04 this was moved to its a separate module loader.
