### PR TITLE
Moving to mod_auth_openid version 0.7.

### DIFF
--- a/attributes/mod_auth_openid.rb
+++ b/attributes/mod_auth_openid.rb
@@ -17,7 +17,7 @@
 # 
 
 default['apache']['mod_auth_openid']['checksum'] = "79e7ca52511d1230"
-default['apache']['mod_auth_openid']['version']  = "0.6"
+default['apache']['mod_auth_openid']['version']  = "0.7"
 default['apache']['mod_auth_openid']['cache_dir']  = "/var/cache/mod_auth_openid"
 default['apache']['mod_auth_openid']['dblocation'] = "#{node['apache']['mod_auth_openid']['cache_dir']}/mod_auth_openid.db"
 

--- a/recipes/mod_auth_openid.rb
+++ b/recipes/mod_auth_openid.rb
@@ -73,7 +73,12 @@ version = node['apache']['mod_auth_openid']['version']
 configure_flags = node['apache']['mod_auth_openid']['configure_flags']
 
 remote_file "#{Chef::Config['file_cache_path']}/mod_auth_openid-#{version}.tar.gz" do
-  source "http://butterfat.net/releases/mod_auth_openid/mod_auth_openid-#{version}.tar.gz"
+#  case version
+#  when "0.7"
+      source "http://cloud.github.com/downloads/bmuller/mod_auth_openid/mod_auth_openid-0.7.tar.gz"
+#  else
+#      source "http://butterfat.net/releases/mod_auth_openid/mod_auth_openid-#{version}.tar.gz"
+#  end
   mode 0644
   checksum _checksum
 end


### PR DESCRIPTION
@jblatt-verticloud 

The current version of mod_auth_openid does not support the full set of open-id features. Upgrading to version  0.7. The location for the source tarball has changed for version 0.7.
