### PR TITLE
[COOK-1804] Fix enabled flag for web_app resource

### DIFF
--- a/definitions/web_app.rb
+++ b/definitions/web_app.rb
@@ -43,7 +43,8 @@ define :web_app, :template => "web_app.conf.erb", :enable => true do
     end
   end
   
+  site_enabled = params[:enable]
   apache_site "#{params[:name]}.conf" do
-    enable params[:enable]
+    enable site_enabled
   end
 end


### PR DESCRIPTION
The enabled flag was being incorrectly passed to apache_site.  The default value defined in apache_site.rb (:enable => true) was always being used making it impossible to create a new web_app in a disabled state.
