### PR TITLE
[COOK-1824] Adds a sysconfig template for rhel/fedora family

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -143,6 +143,16 @@ directory node['apache']['cache_dir'] do
   group node['apache']['root_group']
 end
 
+# Set the preferred execution binary - prefork or worker
+template "/etc/sysconfig/httpd" do
+  source "etc-sysconfig-httpd.erb"
+  owner "root"
+  group node['apache']['root_group']
+  mode 00644
+  notifies :restart, "service[apache2]"
+  only_if { platform_family?("rhel", "fedora") }
+end
+
 template "apache2.conf" do
   case node['platform_family']
   when "rhel", "fedora", "arch"

--- a/templates/default/etc-sysconfig-httpd.erb
+++ b/templates/default/etc-sysconfig-httpd.erb
@@ -1,0 +1,31 @@
+# This file managed by Chef. Changes will be overwritten.
+
+#
+# The default processing model (MPM) is the process-based
+# 'prefork' model.  A thread-based model, 'worker', is also
+# available, but does not work with some modules (such as PHP).
+# The service must be stopped before changing this variable.
+#
+HTTPD=<%= node['apache']['binary'] %>
+
+#
+# To pass additional options (for instance, -D definitions) to the
+# httpd binary at startup, set OPTIONS here.
+#
+#OPTIONS=
+
+#
+# By default, the httpd process is started in the C locale; to
+# change the locale in which the server runs, the HTTPD_LANG
+# variable can be set.
+#
+#HTTPD_LANG=C
+
+#
+# By default, the httpd process will create the file
+# /var/run/httpd/httpd.pid in which it records its process
+# identification number when it starts.  If an alternate location is
+# specified in httpd.conf (via the PidFile directive), the new
+# location needs to be reported in the PIDFILE.
+#
+#PIDFILE=<%= node['apache']['pid_file'] %>


### PR DESCRIPTION
Since changing the Multi-Processing Module differs by distribution, this
commit is solely targeted at the RHEL-style platforms.

Ref: http://tickets.opscode.com/browse/COOK-1824
