### PR TITLE
COOK-2198 apache::mod_auth_openid compiles from source, but does not install make on debian/ubuntu

### DIFF
--- a/recipes/mod_auth_openid.rb
+++ b/recipes/mod_auth_openid.rb
@@ -18,7 +18,7 @@
 #
 
 openid_dev_pkgs = value_for_platform_family(
-  ["debian"] => %w{g++ apache2-prefork-dev libopkele-dev libopkele3},
+  ["debian"] => %w{make g++ apache2-prefork-dev libopkele-dev libopkele3},
   ["rhel", "fedora"] => %w{gcc-c++ httpd-devel curl-devel libtidy libtidy-devel sqlite-devel pcre-devel openssl-devel make},
   "arch" => ["libopkele"],
   "freebsd" => %w{libopkele pcre sqlite3}


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2198

https://github.com/opscode-cookbooks/apache2/blob/master/recipes/mod_auth_openid.rb#L94
