### PR TITLE
COOK-2248 apache2::mod_php5 needs package 'which'

### DIFF
--- a/recipes/mod_php5.rb
+++ b/recipes/mod_php5.rb
@@ -30,6 +30,7 @@ when "arch"
 
 when "rhel"
 
+  package "which"
   package "php package" do
     if node['platform_version'].to_f < 6.0
       package_name "php53"


### PR DESCRIPTION
On minimal centos systems, which is not intsalled.
