### PR TITLE
COOK-2276 : cookbook apache2 documentation regarding listening ports doesn't match default attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ General settings
 These are general settings used in recipes and templates. Default
 values are noted.
 
-* `node['apache']['listen_ports']` - Ports that httpd should listen on. Default is an array of ports 80 and 443.
+* `node['apache']['listen_ports']` - Ports that httpd should listen on. Default is port 80.
 * `node['apache']['contact']` - Value for ServerAdmin directive. Default "ops@example.com".
 * `node['apache']['timeout']` - Value for the Timeout directive. Default is 300.
 * `node['apache']['keepalive']` - Value for the KeepAlive directive. Default is On.


### PR DESCRIPTION
The documentation here :

https://github.com/opscode-cookbooks/apache2/blob/master/README.md#general-settings

says :

```
node['apache']['listen_ports'] - Ports that httpd should listen on. Default is an array of ports 80 and 443.
```

However the default attributes here :

https://github.com/opscode-cookbooks/apache2/blob/master/attributes/default.rb#L106

are set to :

```
default['apache']['listen_ports'] = ["80"]
```

I've opted to update the documentation since I'm guessing that's the least impactful change.

Feel free to test and merge this pull request. Thanks.
