### PR TITLE
Remove misleading statement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ the top of the file.
 * `node['apache']['cache_dir']` - Location for cached files used by Apache itself or recipes
 * `node['apache']['pid_file']` - Location of the PID file for Apache httpd
 * `node['apache']['lib_dir']` - Location for shared libraries
-* `node['apache']['default_site_enabled']` - Default site enabled. Defaults to true on redhat-family platforms
+* `node['apache']['default_site_enabled']` - Default site enabled.
 * `node['apache']['ext_status']` - if true, enables ExtendedStatus for `mod_status`
 
 General settings


### PR DESCRIPTION
`node['apache']['default_site_enabled']` currently defaults to `false` on all
platforms without exceptions.
