### PR TITLE
Better support for SUSE distribution.

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -8,7 +8,7 @@ ServerRoot "<%= node['apache']['dir'] %>"
 #
 # The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
 #
-<% if %w{debian}.include?(node['platform_family']) -%>
+<% if %w{debian suse}.include?(node['platform_family']) -%>
 LockFile /var/lock/apache2/accept.lock
 <% elsif %w{freebsd}.include?(node['platform_family']) -%>
 LockFile /var/log/accept.lock

--- a/templates/default/etc-sysconfig-httpd.erb
+++ b/templates/default/etc-sysconfig-httpd.erb
@@ -1,4 +1,4 @@
-# This file managed by Chef. Changes will be overwritten.
+# This file is managed by Chef. Changes will be overwritten.
 
 #
 # The default processing model (MPM) is the process-based

--- a/templates/suse/etc-sysconfig-httpd.erb
+++ b/templates/suse/etc-sysconfig-httpd.erb
@@ -1,0 +1,52 @@
+# This file is managed by Chef. Changes will be overwritten.
+
+## APACHE_MODULES are managed with /etc/apache2/mods-available.
+
+## Type:	string
+## Default:	""
+## ServiceRestart: apache2
+#
+# Additional server flags:
+#
+# Put here any server flags ("Defines") that you want to hand over to 
+# httpd at start time, or other command line flags.
+#
+# Background: Any directives within an <IfDefine flag>...</IfDefine>
+#             section are only processed if the flag is defined.
+#             This allows to write configuration which is active only in a
+#             special cases, like during server maintenance, or for testing
+#             something temporarily.
+#
+# Notably, to enable ssl support, 'SSL' needs to be added here.
+# To enable the server-status, 'STATUS' needs to be added here.
+#
+# It does not matter if you write flag1, -D flag1 or -Dflag1.
+# Multiple flags can be given as "-D flag1 -D flag2" or simply "flag1 flag2".
+#
+# Specifying such flags here is equivalent to giving them on the commandline.
+# (e.g. via rcapache2 start -DReverseProxy)
+#
+# Example:
+#      "SSL STATUS AWSTATS SVN_VIEWCVS no_subversion_today"
+#
+APACHE_SERVER_FLAGS="<%= node['apache']['server_flags'] %>"
+
+## Type:	string
+## Default:	""
+## ServiceRestart: apache2
+#
+# Which config file do you want to use?
+# (if not set, /etc/apache2/httpd.conf is used.)
+# It is unusual to need to use this setting.
+#
+# Note about ulimits:
+#   if you want to set ulimits, e.g. to increase the max number of open file handle, 
+#   or to allow core files, you can do so by editing /etc/sysconfig/apache2 and
+#   simply write the ulimit commands into that file.
+#   Example:
+#     ulimit -n 16384
+#     ulimit -H -n 16384
+#     ulimit -c unlimited
+#   See the output of "help ulimit" in the bash, or "man 1 ulimit".
+#
+APACHE_HTTPD_CONF="<%= node['apache']['httpd_conf'] %>"


### PR DESCRIPTION
- recipes/default.rb:
  - Corrected service commands
  - Corrected support for `a2enmod` and `a2dismod`
  - Corrected support for template in `/etc/sysconfig`. Now path is
    parameterized with the name of the package.
  - Corrected path to `httpd.conf`
  - Unused files now are removed
- templates/default/apache2.conf.erb:
  - Specified platform family
- templates/default/etc-sysconfig-httpd.erb:
  - Typo
- templates/suse/etc-sysconfig-httpd.erb:
  - Created specific template for `/etc/sysconfig/apache2`
