### PR TITLE
[COOK-2434] Better support for SUSE distribution

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ default['apache']['root_group'] = 'root'
 
 # Where the various parts of apache are
 case node['platform']
-when 'redhat', 'centos', 'scientific', 'fedora', 'suse', 'amazon', 'oracle'
+when 'redhat', 'centos', 'scientific', 'fedora', 'amazon', 'oracle'
   default['apache']['package']     = 'httpd'
   default['apache']['dir']         = '/etc/httpd'
   default['apache']['log_dir']     = '/var/log/httpd'
@@ -42,22 +42,39 @@ when 'redhat', 'centos', 'scientific', 'fedora', 'suse', 'amazon', 'oracle'
   default['apache']['lib_dir']     = node['kernel']['machine'] =~ /^i[36]86$/ ? '/usr/lib/httpd' : '/usr/lib64/httpd'
   default['apache']['libexecdir']  = "#{node['apache']['lib_dir']}/modules"
   default['apache']['default_site_enabled'] = false
-when 'debian', 'ubuntu'
-  default['apache']['package']     = 'apache2'
-  default['apache']['dir']         = '/etc/apache2'
-  default['apache']['log_dir']     = '/var/log/apache2'
-  default['apache']['error_log']   = 'error.log'
-  default['apache']['access_log']  = 'access.log'
-  default['apache']['user']        = 'www-data'
-  default['apache']['group']       = 'www-data'
-  default['apache']['binary']      = '/usr/sbin/apache2'
-  default['apache']['docroot_dir'] = '/var/www'
-  default['apache']['cgibin_dir']  = '/usr/lib/cgi-bin'
-  default['apache']['icondir']     = '/usr/share/apache2/icons'
-  default['apache']['cache_dir']   = '/var/cache/apache2'
-  default['apache']['pid_file']    = '/var/run/apache2.pid'
-  default['apache']['lib_dir']     = '/usr/lib/apache2'
-  default['apache']['libexecdir']  = "#{node['apache']['lib_dir']}/modules"
+when 'suse'
+  default['apache']['package']      = "apache2"
+  default['apache']['dir']          = "/etc/apache2"
+  default['apache']['log_dir']      = "/var/log/apache2"
+  default['apache']['error_log']    = "error.log"
+  default['apache']['user']         = "wwwrun"
+  default['apache']['group']        = "www"
+  default['apache']['binary']       = "/usr/sbin/apache2"
+  default['apache']['icondir']      = "/var/www/icons"
+  default['apache']['cache_dir']    = "/var/cache/apache2"
+  default['apache']['pid_file']     = "/run/httpd2.pid"
+  default['apache']['lib_dir']      = node['kernel']['machine'] =~ /^i[36']86$/ ? "/usr/lib/apache2" : "/usr/lib64/apache2"
+  default['apache']['libexecdir']   = node['apache']['lib_dir']
+  default['apache']['default_site_enabled'] = false
+  default['apache']['server_flags'] = ''
+  default['apache']['httpd_conf']   = ''
+  default['apache']['docroot']      = '/srv/www/htdocs'
+when "debian", "ubuntu"
+  default['apache']['package']      = "apache2"
+  default['apache']['dir']          = "/etc/apache2"
+  default['apache']['log_dir']      = "/var/log/apache2"
+  default['apache']['error_log']    = "error.log"
+  default['apache']['access_log']   = "access.log"
+  default['apache']['user']         = "www-data"
+  default['apache']['group']        = "www-data"
+  default['apache']['binary']       = "/usr/sbin/apache2"
+  default['apache']['docroot_dir']  = "/var/www"
+  default['apache']['cgibin_dir']   = "/usr/lib/cgi-bin"
+  default['apache']['icondir']      = "/usr/share/apache2/icons"
+  default['apache']['cache_dir']    = "/var/cache/apache2"
+  default['apache']['pid_file']     = "/var/run/apache2.pid"
+  default['apache']['lib_dir']      = "/usr/lib/apache2"
+  default['apache']['libexecdir']   = "#{node['apache']['lib_dir']}/modules"
   default['apache']['default_site_enabled'] = false
 when 'arch'
   default['apache']['package']     = 'apache'

--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -8,7 +8,7 @@ ServerRoot "<%= node['apache']['dir'] %>"
 #
 # The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
 #
-<% if %w[debian].include?(node['platform_family']) -%>
+<% if %w{debian suse}.include?(node['platform_family']) -%>
 LockFile /var/lock/apache2/accept.lock
 <% elsif %w[freebsd].include?(node['platform_family']) -%>
 LockFile /var/log/accept.lock

--- a/templates/default/etc-sysconfig-httpd.erb
+++ b/templates/default/etc-sysconfig-httpd.erb
@@ -1,4 +1,4 @@
-# This file managed by Chef. Changes will be overwritten.
+# This file is managed by Chef. Changes will be overwritten.
 
 #
 # The default processing model (MPM) is the process-based

--- a/templates/suse/etc-sysconfig-httpd.erb
+++ b/templates/suse/etc-sysconfig-httpd.erb
@@ -1,0 +1,52 @@
+# This file is managed by Chef. Changes will be overwritten.
+
+## APACHE_MODULES are managed with /etc/apache2/mods-available.
+
+## Type:	string
+## Default:	""
+## ServiceRestart: apache2
+#
+# Additional server flags:
+#
+# Put here any server flags ("Defines") that you want to hand over to 
+# httpd at start time, or other command line flags.
+#
+# Background: Any directives within an <IfDefine flag>...</IfDefine>
+#             section are only processed if the flag is defined.
+#             This allows to write configuration which is active only in a
+#             special cases, like during server maintenance, or for testing
+#             something temporarily.
+#
+# Notably, to enable ssl support, 'SSL' needs to be added here.
+# To enable the server-status, 'STATUS' needs to be added here.
+#
+# It does not matter if you write flag1, -D flag1 or -Dflag1.
+# Multiple flags can be given as "-D flag1 -D flag2" or simply "flag1 flag2".
+#
+# Specifying such flags here is equivalent to giving them on the commandline.
+# (e.g. via rcapache2 start -DReverseProxy)
+#
+# Example:
+#      "SSL STATUS AWSTATS SVN_VIEWCVS no_subversion_today"
+#
+APACHE_SERVER_FLAGS="<%= node['apache']['server_flags'] %>"
+
+## Type:	string
+## Default:	""
+## ServiceRestart: apache2
+#
+# Which config file do you want to use?
+# (if not set, /etc/apache2/httpd.conf is used.)
+# It is unusual to need to use this setting.
+#
+# Note about ulimits:
+#   if you want to set ulimits, e.g. to increase the max number of open file handle, 
+#   or to allow core files, you can do so by editing /etc/sysconfig/apache2 and
+#   simply write the ulimit commands into that file.
+#   Example:
+#     ulimit -n 16384
+#     ulimit -H -n 16384
+#     ulimit -c unlimited
+#   See the output of "help ulimit" in the bash, or "man 1 ulimit".
+#
+APACHE_HTTPD_CONF="<%= node['apache']['httpd_conf'] %>"


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-2434
- recipes/default.rb:
  - Corrected service commands
  - Corrected support for `a2enmod` and `a2dismod`
  - Corrected support for template in `/etc/sysconfig`. Now path is
    parameterized with the name of the package.
  - Corrected path to `httpd.conf`
- templates/default/apache2.conf.erb:
  - Specified platform family
- templates/default/etc-sysconfig-httpd.erb:
  - Typo
- templates/suse/etc-sysconfig-httpd.erb:
  - Created specific template for `/etc/sysconfig/apache2`
- attributes/default.rb:
  - SUSE-specific attribute values. Added `['apache']['docroot']`
    attribute to the default ones. I think it could be useful to determine the
    node-level prefix of the vhosts.
