### PR TITLE
[COOK-2564] - Apache VirtualHost port in web_app

### DIFF
--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:<%= @params[:server_port] || node['apache']['listen_ports'].first %>>
   ServerName <%= @params[:server_name] %>
   ServerAlias <% @params[:server_aliases].each do |a| %><%= a %> <% end %>
   DocumentRoot <%= @params[:docroot] %>


### PR DESCRIPTION
- Allow port in web_app config (e.g. server_port 8080)
- Default to first Apache Listen port if not defined

http://tickets.opscode.com/browse/COOK-2564
