### PR TITLE
[COOK-3562] Allow mod_proxy settings to be configured on the node

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -141,6 +141,11 @@ default['apache']['worker']['maxsparethreads'] = 192
 default['apache']['worker']['threadsperchild'] = 64
 default['apache']['worker']['maxrequestsperchild'] = 0
 
+# mod_proxy settings
+default['apache']['proxy']['order'] = 'deny,allow'
+default['apache']['proxy']['deny_from'] = 'all'
+default['apache']['proxy']['allow_from'] = 'none'
+
 # Default modules to enable via include_recipe
 
 default['apache']['default_modules'] = %w{

--- a/templates/default/mods/proxy.conf.erb
+++ b/templates/default/mods/proxy.conf.erb
@@ -6,9 +6,9 @@
 
         <Proxy *>
                 AddDefaultCharset off
-                Order deny,allow
-                Deny from all
-                #Allow from .example.com
+                Order <%= node[:apache][:proxy][:order] %>
+                Deny from <%= node[:apache][:proxy][:deny_from] %>
+                Allow from <%= node[:apache][:proxy][:allow_from] %>
         </Proxy>
 
         # Enable/disable the handling of HTTP/1.1 "Via:" headers.


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3562

Gives the ability to set the Order, Deny and Allow configuration via node attributes.
