### PR TITLE
COOK-2720 - Apache2 minitest helper function ran_recipe is not portable ...

### DIFF
--- a/files/default/tests/minitest/support/helpers.rb
+++ b/files/default/tests/minitest/support/helpers.rb
@@ -48,7 +48,18 @@ module Helpers
     end
 
     def ran_recipe?(recipe)
-      node.run_state[:seen_recipes].keys.include?(recipe)
+      if Chef::VERSION < "11.0"
+        seen_recipes = node.run_state[:seen_recipes]
+        recipes = seen_recipes.keys.each { |i| i }
+      else
+        recipes = run_context.loaded_recipes
+      end
+      if recipes.empty? and Chef::Config[:solo]
+        #If you have roles listed in your run list they are NOT expanded
+        recipes = node.run_list.map {|item| item.name if item.type == :recipe }
+      end
+      recipes.include?(recipe)
     end
+
   end
 end


### PR DESCRIPTION
...fixed

Re-used code originally written by bryanwb for the Chef-Minitest-handler cookbook. 

That code's license: Apache 2.0
Origin: https://github.com/btm/minitest-handler-cookbook/blob/master/recipes/default.rb line 18.
