### PR TITLE
Make log level configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -109,6 +109,7 @@ default['apache']['timeout'] = 300
 default['apache']['keepalive'] = "On"
 default['apache']['keepaliverequests'] = 100
 default['apache']['keepalivetimeout'] = 5
+default['apache']['log_level'] = "warn"
 
 # Security
 default['apache']['servertokens'] = "Prod"

--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -137,7 +137,7 @@ ErrorLog <%= node['apache']['log_dir'] %>/<%= node['apache']['error_log'] %>
 # Possible values include: debug, info, notice, warn, error, crit,
 # alert, emerg.
 #
-LogLevel warn
+LogLevel <%= node['apache']['log_level'] %>
 
 # COOK-1021: Dummy LoadModule directive to aid module installations
 #LoadModule dummy_module modules/mod_dummy.so


### PR DESCRIPTION
The Apache log level should be configurable using Chef attributes.
