### PR TITLE
COOK-3027 Default site enable true->false not right outcome

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -215,7 +215,7 @@ node['apache']['default_modules'].each do |mod|
 end
 
 apache_site "default" do
-  enable !!node['apache']['default_site_enabled']
+  enable node['apache']['default_site_enabled']
 end
 
 service "apache2" do


### PR DESCRIPTION
This commit fixes an issue where a converge with
default_site_enabled = true, then default_site_enabled = false,
does not disable the default site.
