### PR TITLE
Removed duplicate use of RewriteEngine On

### DIFF
--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -2,7 +2,6 @@
   ServerName <%= @params[:server_name] %>
   ServerAlias <% @params[:server_aliases].each do |a| %><%= a %> <% end %>
   DocumentRoot <%= @params[:docroot] %>
-  RewriteEngine On
 
   <Directory <%= @params[:docroot] %>>
     Options <%= [@params[:directory_options] || "FollowSymLinks" ].flatten.join " " %>


### PR DESCRIPTION
`RewriteEngine On` was found two places in the template. Removed one of them.
