### PR TITLE
[COOK-3307] Make modfastcgi-configuration file optional 

### DIFF
--- a/attributes/mod_fastcgi.rb
+++ b/attributes/mod_fastcgi.rb
@@ -1,0 +1,1 @@
+default['apache']['mod_fastcgi']['default_config'] = true

--- a/recipes/mod_fastcgi.rb
+++ b/recipes/mod_fastcgi.rb
@@ -21,6 +21,6 @@ if platform_family?("debian")
   package "libapache2-mod-fastcgi"
 
   apache_module "fastcgi" do
-    conf true
+    conf node['apache']['mod_fastcgi']['default_config']
   end
 end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3307

Adds an attribute to enable/disable the default mod-fastcgi template
