### PR TITLE
[COOK-3646] Recipe for mod_cloudflare

### DIFF
--- a/recipes/mod_cloudflare.rb
+++ b/recipes/mod_cloudflare.rb
@@ -1,3 +1,22 @@
+#
+# Cookbook Name:: apache2
+# Recipe:: cloudflare 
+#
+# Copyright 2008-2009, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apt_repository "cloudflare" do
   uri "http://pkg.cloudflare.com"
   distribution node['lsb']['codename']


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3646

Adds the CloudFlare CDN module, which means client IP addresses are logged correctly in Apache.
