### PR TITLE
[COOK-3757] Provide missing variable to ports.conf

### DIFF
--- a/recipes/mod_ssl.rb
+++ b/recipes/mod_ssl.rb
@@ -38,7 +38,7 @@ template "#{node['apache']['dir']}/ports.conf" do
   mode      '0644'
   variables(
     :apache_listen_addresses => node['apache']['listen_addresses'].uniq,
-    :apache_listen_ports => node['apache']['listen_ports'].map { |p| p.to_i }.uniq
+    :apache_listen_ports => ports.map { |p| p.to_i }.uniq
   )
   notifies  :restart, 'service[apache2]'
 end


### PR DESCRIPTION
The ports.conf.erb template requires apache_listen_addresses this is not
done by the mod_ssl recipe (though default does this correctly).
