### PR TITLE
[COOK-3766] The ports.conf template expects an @apache_listen_addresses variable

### DIFF
--- a/recipes/mod_ssl.rb
+++ b/recipes/mod_ssl.rb
@@ -36,7 +36,10 @@ end
 template "#{node['apache']['dir']}/ports.conf" do
   source    'ports.conf.erb'
   mode      '0644'
-  variables(:apache_listen_ports => ports.map { |p| p.to_i }.uniq)
+  variables(
+    :apache_listen_ports => ports.map { |p| p.to_i }.uniq,
+    :apache_listen_addresses => node['apache']['listen_addresses'].uniq
+  )
   notifies  :restart, 'service[apache2]'
 end
 


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3766

Pass apache_listen_addresses to the ports.conf template.
