### PR TITLE
[COOK-3769] Uncomment the enabling of apache modules & fix the `not_if`

### DIFF
--- a/definitions/apache_module.rb
+++ b/definitions/apache_module.rb
@@ -33,14 +33,14 @@ define :apache_module, :enable => true, :conf => false do
   end
 
   if params[:enable]
-    # execute "a2enmod #{params[:name]}" do
-    #   command "/usr/sbin/a2enmod #{params[:name]}"
-    #   notifies :restart, 'service[apache2]'
-    #   not_if do
-    #     ::File.symlink?("#{node['apache']['dir']}/mods-enabled/#{params[:name]}.load") &&
-    #     ::File.exists?("#{node['apache']['dir']}/mods-available/#{params[:name]}.conf") ? ::File.symlink?("#{node['apache']['dir']}/mods-enabled/#{params[:name]}.conf") : true
-    #   end
-    # end
+    execute "a2enmod #{params[:name]}" do
+      command "/usr/sbin/a2enmod #{params[:name]}"
+      notifies :restart, 'service[apache2]'
+      not_if do
+        ::File.symlink?("#{node['apache']['dir']}/mods-enabled/#{params[:name]}.load") &&
+        (::File.exists?("#{node['apache']['dir']}/mods-available/#{params[:name]}.conf") ? ::File.symlink?("#{node['apache']['dir']}/mods-enabled/#{params[:name]}.conf") : true)
+      end
+    end
   else
     execute "a2dismod #{params[:name]}" do
       command "/usr/sbin/a2dismod #{params[:name]}"


### PR DESCRIPTION
The `apache_module` should be able to enable modules
