### PR TITLE
[COOK-3800] add identifier param to apache2_module

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ the definition is used. See __Examples__.
 ### Parameters:
 
 * `name` - Name of the module enabled or disabled with the `a2enmod` or `a2dismod` scripts.
+* `identifier` - String to identify the module for the `LoadModule` directive. Not typically needed, defaults to `#{name}_module`
 * `enable` - Default true, which uses `a2enmod` to enable the module. If false, the module will be disabled with `a2dismod`.
 * `conf` - Default false. Set to true if the module has a config file, which will use `apache_conf` for the file.
 * `filename` - specify the full name of the file, e.g.

--- a/definitions/apache_module.rb
+++ b/definitions/apache_module.rb
@@ -22,12 +22,13 @@ define :apache_module, :enable => true, :conf => false do
 
   params[:filename]    = params[:filename] || "mod_#{params[:name]}.so"
   params[:module_path] = params[:module_path] || "#{node['apache']['libexecdir']}/#{params[:filename]}"
+  params[:identifier] = params[:identifier] || "#{params[:name]}_module"
 
   apache_conf params[:name] if params[:conf]
 
   if platform_family?('rhel', 'fedora', 'arch', 'suse', 'freebsd')
     file "#{node['apache']['dir']}/mods-available/#{params[:name]}.load" do
-      content "LoadModule #{params[:name]}_module #{params[:module_path]}\n"
+      content "LoadModule #{params[:identifier]} #{params[:module_path]}\n"
       mode    '0644'
     end
   end


### PR DESCRIPTION
Some modules don't have normal identifiers of name_module and so the LoadModule directive won't work. This provides a parameter to change that identifier if you don't want the default.
