### PR TITLE
templatize the envvars file [#COOK-3917]

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -146,6 +146,16 @@ template '/etc/sysconfig/httpd' do
   only_if  { platform_family?('rhel', 'fedora') }
 end
 
+template 'envvars' do
+  path "#{node['apache']['dir']}/envvars"
+  source   'envvars.erb'
+  owner    'root'
+  group    node['apache']['root_group']
+  mode     '0644'
+  notifies :restart, 'service[apache2]'
+  only_if  { platform_family?('debian') }
+end
+
 template 'apache2.conf' do
   case node['platform_family']
   when 'rhel', 'fedora', 'arch'

--- a/templates/default/envvars.erb
+++ b/templates/default/envvars.erb
@@ -1,0 +1,40 @@
+# envvars - default environment variables for apache2ctl
+
+# this won't be correct after changing uid
+unset HOME
+
+# Since there is no sane way to get the parsed apache2 config in scripts, some
+# settings are defined via environment variables and then used in apache2ctl,
+# /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
+export APACHE_RUN_USER=<%= node['apache']['user'] %>
+export APACHE_RUN_GROUP=<%= node['apache']['group'] %>
+# temporary state file location. This might be changed to /run in Wheezy+1
+export APACHE_PID_FILE=<%= node['apache']['pid_file'] %>
+export APACHE_RUN_DIR=/var/run/apache2
+export APACHE_LOCK_DIR=/var/lock/apache2
+# Only /var/log/apache2 is handled by /etc/logrotate.d/apache2.
+export APACHE_LOG_DIR=<%= node['apache']['log_dir'] %>
+
+## The locale used by some modules like mod_dav
+export LANG=C
+## Uncomment the following line to use the system default locale instead:
+#. /etc/default/locale
+
+export LANG
+
+## The command to get the status for 'apache2ctl status'.
+## Some packages providing 'www-browser' need '--dump' instead of '-dump'.
+#export APACHE_LYNX='www-browser -dump'
+
+## If you need a higher file descriptor limit, uncomment and adjust the
+## following line (default is 8192):
+#APACHE_ULIMIT_MAX_FILES='ulimit -n 65536'
+
+## If you would like to pass arguments to the web server, add them below
+## to the APACHE_ARGUMENTS environment.
+#export APACHE_ARGUMENTS=''
+
+## Enable the debug mode for maintainer scripts.
+## This will produce a verbose output on package installations of web server modules and web application
+## installations which interact with Apache
+#export APACHE2_MAINTSCRIPT_DEBUG=1


### PR DESCRIPTION
This patch addresses: https://tickets.opscode.com/browse/COOK-3917

The envvars file (typically installed into /etc/apache2/envvars) sets some environment variables that are used by the init script.

It sets the user to run as, group, pidfile location, etc.

Previous versions of the cookbook didn't include this file, so the init system would be using the wrong pidfile location, for example, and wouldn't know how to stop/restart apache.

This version uses the same values that are used in the rest of the apache2 configuration.
