### PR TITLE
Move the pidfile for Ubuntu >= 13.10 [COOK-3919]

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,7 +55,11 @@ when 'debian', 'ubuntu'
   default['apache']['cgibin_dir']  = '/usr/lib/cgi-bin'
   default['apache']['icondir']     = '/usr/share/apache2/icons'
   default['apache']['cache_dir']   = '/var/cache/apache2'
-  default['apache']['pid_file']    = '/var/run/apache2.pid'
+  default['apache']['pid_file']    = if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 13.10
+                                       '/var/run/apache2/apache2.pid'
+                                     else
+                                       '/var/run/apache2.pid'
+                                     end
   default['apache']['lib_dir']     = '/usr/lib/apache2'
   default['apache']['libexecdir']  = "#{node['apache']['lib_dir']}/modules"
   default['apache']['default_site_enabled'] = false


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3919

Ubuntu has moved the location of the pidfile for the apache2 package to /var/run/apache2/apache2.pid (it was /var/run/apache2.pid).

This should be reflected in the default attributes

Ubuntu 13.10 also upgraded to Apache 2.4 which causes other issues, but that is addressed in another pull request which handles Apache 2.4 generically, while this is an ubuntu specific move.
