### PR TITLE
[COOK-4076] FC007: dependencies are not defined properly

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -58,6 +58,9 @@ supports 'redhat'
 supports 'scientific'
 supports 'ubuntu'
 
+depends 'logrotate'
+depends 'pacman'
+
 attribute 'apache',
           :display_name => 'Apache Hash',
           :description  => 'Hash of Apache attributes',


### PR DESCRIPTION
Dependencies of the cookbook have to be defined in the metadata.rb

Foodcritic shows on FC007:
FC007: Ensure recipe dependencies are reflected in cookbook metadata: cookbooks/apache2/recipes/logrotate.rb:25
FC007: Ensure recipe dependencies are reflected in cookbook metadata: cookbooks/apache2/recipes/mod_auth_openid.rb:34
