### PR TITLE
[COOK-4490] Fix minitest `apache_configured_ports` helper

### DIFF
--- a/files/default/tests/minitest/support/helpers.rb
+++ b/files/default/tests/minitest/support/helpers.rb
@@ -14,7 +14,7 @@ module Helpers
 
     def apache_configured_ports
       port_config = File.read("#{node['apache']['dir']}/ports.conf")
-      port_config.scan(/^Listen ([0-9]+)/).flatten.map { |p| p.to_i }
+      port_config.scan(/^Listen (?:[^: ]+:)?([0-9]+)/).flatten.map { |p| p.to_i }
     end
 
     def apache_enabled_modules


### PR DESCRIPTION
With a default installation, the `ports.conf` file content is actually

```
Listen *:80
NameVirtualHost *:80
Listen *:443
NameVirtualHost *:443
```

which the original regexp can't handle.
