### PR TITLE
[COOK-4491] fix minitest: escape regex interpolation

### DIFF
--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -36,7 +36,8 @@ describe 'apache2::default' do
   end
 
   it 'reports server name only, not detailed version info' do
-    assert_match(/^ServerTokens #{node['apache']['servertokens']} *$/, File.read("#{node['apache']['dir']}/conf.d/security"))
+    assert_match(/^ServerTokens #{Regexp.escape(node['apache']['servertokens'])} *$/,
+      File.read("#{node['apache']['dir']}/conf.d/security"))
   end
 
   it 'listens on port 80' do
@@ -50,7 +51,8 @@ describe 'apache2::default' do
   end
 
   it 'reports server name only, not detailed version info' do
-    file("#{node['apache']['dir']}/conf.d/security").must_match(/^ServerTokens #{node['apache']['servertokens']} *$/)
+    file("#{node['apache']['dir']}/conf.d/security").must_match(
+      /^ServerTokens #{Regexp.escape(node['apache']['servertokens'])} *$/)
   end
 
   it 'enables default_modules' do

--- a/files/default/tests/minitest/mod_ssl_test.rb
+++ b/files/default/tests/minitest/mod_ssl_test.rb
@@ -22,7 +22,7 @@ describe 'apache2::mod_ssl' do
 
   it 'configures SSLCiphersuit from an attribute' do
     assert_match(
-      /^SSLCipherSuite #{node['apache']['mod_ssl']['cipher_suite']}$/,
+      /SSLCipherSuite #{Regexp.escape(node['apache']['mod_ssl']['cipher_suite'])}$/,
       File.read("#{node['apache']['dir']}/mods-enabled/ssl.conf")
       )
   end


### PR DESCRIPTION
Default value for `node['apache']['mod_ssl']['cipher_suite']` is `RC4-SHA:HIGH:!ADH`, which is regex-unsafe. I also secured other user-configurable interpolations.

Also changed a minor issue with `^SSLCipherSuite` regex not detecting indented line.
