### PR TITLE
[COOK-4492] Fix service[apache2] CHEF-3694 duplication

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,28 +21,6 @@ package 'apache2' do
   package_name node['apache']['package']
 end
 
-service 'apache2' do
-  case node['platform_family']
-  when 'rhel', 'fedora', 'suse'
-    service_name 'httpd'
-    # If restarted/reloaded too quickly httpd has a habit of failing.
-    # This may happen with multiple recipes notifying apache to restart - like
-    # during the initial bootstrap.
-    restart_command '/sbin/service httpd restart && sleep 1'
-    reload_command '/sbin/service httpd reload && sleep 1'
-  when 'debian'
-    service_name 'apache2'
-    restart_command '/usr/sbin/invoke-rc.d apache2 restart && sleep 1'
-    reload_command '/usr/sbin/invoke-rc.d apache2 reload && sleep 1'
-  when 'arch'
-    service_name 'httpd'
-  when 'freebsd'
-    service_name 'apache22'
-  end
-  supports [:restart, :reload, :status]
-  action :enable
-end
-
 if platform_family?('rhel', 'fedora', 'arch', 'suse', 'freebsd')
   directory node['apache']['log_dir'] do
     mode '0755'
@@ -208,5 +186,23 @@ apache_site 'default' do
 end
 
 service 'apache2' do
-  action :start
+  case node['platform_family']
+  when 'rhel', 'fedora', 'suse'
+    service_name 'httpd'
+    # If restarted/reloaded too quickly httpd has a habit of failing.
+    # This may happen with multiple recipes notifying apache to restart - like
+    # during the initial bootstrap.
+    restart_command '/sbin/service httpd restart && sleep 1'
+    reload_command '/sbin/service httpd reload && sleep 1'
+  when 'debian'
+    service_name 'apache2'
+    restart_command '/usr/sbin/invoke-rc.d apache2 restart && sleep 1'
+    reload_command '/usr/sbin/invoke-rc.d apache2 reload && sleep 1'
+  when 'arch'
+    service_name 'httpd'
+  when 'freebsd'
+    service_name 'apache22'
+  end
+  supports [:restart, :reload, :status]
+  action [:enable, :start]
 end


### PR DESCRIPTION
This fixes an instance of [CHEF-3694 ](https://tickets.opscode.com/browse/CHEF-3694) in the apache2 cookbook.

I am not entirely sure why the `enable` action was moved to the top of the script (I couldn't find anything that requires it). If this isn't acceptable, I can always use two `service`'s with a different name.
