### PR TITLE
[COOK-4493] Fix template[ports.conf] CHEF-3694 duplication

### DIFF
--- a/recipes/mod_ssl.rb
+++ b/recipes/mod_ssl.rb
@@ -31,7 +31,8 @@ if platform_family?('rhel', 'fedora', 'suse')
   end
 end
 
-template "#{node['apache']['dir']}/ports.conf" do
+template 'ssl_ports.conf' do
+  path      "#{node['apache']['dir']}/ports.conf"
   source    'ports.conf.erb'
   mode      '0644'
   notifies  :restart, 'service[apache2]'


### PR DESCRIPTION
This fixes an instance of [CHEF-3694 ](https://tickets.opscode.com/browse/CHEF-3694) in the apache2 cookbook if you include both `apache2::default` and `apache2::mod_ssl`.
