### PR TITLE
Ubuntu Precise does not have the ask-for-passphrase script, revert to SS...

### DIFF
--- a/templates/default/mods/ssl.conf.erb
+++ b/templates/default/mods/ssl.conf.erb
@@ -33,7 +33,7 @@
   #   Configure the pass phrase gathering process.
   #   The filtering dialog program (`builtin' is a internal
   #   terminal dialog) has to provide the pass phrase on stdout.
-<% if %w[debian].include?(node['platform_family']) && node['apache']['version'] == '2.4' -%>
+<% if %w[debian].include?(node['platform_family']) && node['apache']['version'] == '2.4' && node['platform'] != 'ubuntu' -%>
   SSLPassPhraseDialog exec:/usr/share/apache2/ask-for-passphrase
 <% else -%>
   SSLPassPhraseDialog  builtin


### PR DESCRIPTION
On Ubuntu 12.04 Precise with httpd 2.4, the script ask-for-passphrase is not installed.
I didn't check yet on Ubuntu 13.04 and 14.04 if the script is included, but we can safely use SSLPassphrase builtin for all Ubuntu
