### PR TITLE
Make apache2 service action configurable.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -184,3 +184,6 @@ default['apache']['default_modules'] = %w[
 %w[log_config logio].each do |log_mod|
   default['apache']['default_modules'] << log_mod if %w[rhel fedora suse arch freebsd].include?(node['platform_family'])
 end
+
+# What to do when the apache2 service is installed.
+default['apache']['install_action'] = [:enable, :start]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -204,5 +204,5 @@ service 'apache2' do
     service_name 'apache22'
   end
   supports [:restart, :reload, :status]
-  action [:enable, :start]
+  action node['apache']['install_action']
 end


### PR DESCRIPTION
Assuming the following recipe:

``` ruby
include_recipe 'apache2'
include_recipe 'apache2::mod_php5'
template '/etc/apache2/sites-available/mysite.conf' do
# ...
end 
```

If I've made a mistake in the config template, I can't just fix it and rerun Chef since the 'apache2' recipe tries to start the service which of course fails since I haven't reached the line that replaces the faulty config.
