### PR TITLE
Explicitly use Chef::Provider::Service::Debian on Debian/Ubuntu (was #150)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -195,6 +195,7 @@ service 'apache2' do
     restart_command '/sbin/service httpd restart && sleep 1'
     reload_command '/sbin/service httpd reload && sleep 1'
   when 'debian'
+    provider Chef::Provider::Service::Debian
     service_name 'apache2'
     restart_command '/usr/sbin/invoke-rc.d apache2 restart && sleep 1'
     reload_command '/usr/sbin/invoke-rc.d apache2 reload && sleep 1'


### PR DESCRIPTION
The next version of Chef will use Chef::Provider::Service::Upstart by
default in Ubuntu 13.10+ [Changelog], [CHEF-5276]), because Ubuntu
stopped shipping compatibility links in /etc/init.d/ [bug], [wiki].

[Changelog] https://github.com/opscode/chef/blob/master/CHANGELOG.md
[CHEF-5276] https://tickets.opscode.com/browse/CHEF-5276
[bug]
https://bugs.launchpad.net/ubuntu/+source/rsyslog/+bug/1311810/comments/4
[wiki] https://wiki.ubuntu.com/UpstartCompatibleInitScripts
