### PR TITLE
Correct mod_basic/digest recipe names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Where additional configuration or behavior is used, it is documented
 below in more detail.
 
 The following recipes merely enable the specified module: `mod_alias`,
-`mod_basic`, `mod_digest`, `mod_authn_file`, `mod_authnz_ldap`,
+`mod_auth_basic`, `mod_auth_digest`, `mod_authn_file`, `mod_authnz_ldap`,
 `mod_authz_default`, `mod_authz_groupfile`, `mod_authz_host`,
 `mod_authz_user`, `mod_autoindex`, `mod_cgi`, `mod_dav_fs`,
 `mod_dav_svn`, `mod_deflate`, `mod_dir`, `mod_env`, `mod_expires`,


### PR DESCRIPTION
- `mod_basic` is `mod_auth_basic`
- `mod_digest` is `mod_auth_digest`
