### PR TITLE
a2ensite command should match File.exist? guard

### DIFF
--- a/definitions/apache_site.rb
+++ b/definitions/apache_site.rb
@@ -22,7 +22,7 @@ define :apache_site, :enable => true do
 
   if params[:enable]
     execute "a2ensite #{params[:name]}" do
-      command "/usr/sbin/a2ensite #{params[:name]}"
+      command "/usr/sbin/a2ensite #{params[:name]}.conf"
       notifies :reload, 'service[apache2]'
       not_if do
         ::File.symlink?("#{node['apache']['dir']}/sites-enabled/#{params[:name]}") ||


### PR DESCRIPTION
Please see https://github.com/onehealth-cookbooks/apache2/issues/149 for an explanation of why this change is required. Because `#{params[:name]}.conf` is used in the `only_if` that guards the execution of a2ensite, and because this cookbook creates files with naming convention `#{params[:name]}.conf`, we should be calling a2ensite with that same argument (`"a2ensite #{params[:name]}.conf"` instead of `"a2ensite #{params[:name]}"`).

In https://github.com/onehealth-cookbooks/apache2/issues/149, it is stated that `#{params[:name]}` already ends in `.conf`, but my testing shows that isn't true. And the code also shows that `.conf` is not appended when web_app calls apache_site: https://github.com/onehealth-cookbooks/apache2/blob/COOK-3900/definitions/web_app.rb#L46
