### PR TITLE
Start service check

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -152,6 +152,9 @@ default['apache']['ext_status'] = false
 # mod_info Allow list, space seprated list of allowed entries.
 default['apache']['info_allow_list'] = 'localhost ip6-localhost'
 
+# Enable and start apache2
+default['apache']['start_service'] = "true"
+
 # Prefork Attributes
 default['apache']['prefork']['startservers']        = 16
 default['apache']['prefork']['minspareservers']     = 16

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -201,8 +201,13 @@ service 'apache2' do
   when 'arch'
     service_name 'httpd'
   when 'freebsd'
-    service_name 'apache22'
+    service_name 'apache2'
   end
   supports [:restart, :reload, :status]
-  action [:enable, :start]
+    case node['apache']['start_service']
+  when "true"
+    action [:enable, :start]
+  when "false"
+    action [:nothing]
+  end
 end


### PR DESCRIPTION
I've added an attribute start_service. In some cases apache2 should start after installation.
