### PR TITLE
Added logic to only allow suse deletes for apache2 2.4 and higher.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -123,7 +123,7 @@ if platform_family?('freebsd')
   end
 end
 
-if platform_family?('suse')
+if platform_family?('suse') && node['apache']['version'] >= '2.4' 
 
   directory "#{node['apache']['dir']}/vhosts.d" do
     action :delete


### PR DESCRIPTION
This was needed to allow for these directories and files to remain for Apache2 2.2 installs.
