### PR TITLE
When platform has not been detected perl_pkg is nil. Do not try to install perl package

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,7 +82,7 @@ directory node['apache']['log_dir'] do
 end
 
 # perl is needed for the a2* scripts
-package node['apache']['perl_pkg']
+package node['apache']['perl_pkg'] unless node['apache']['perl_pkg'].nil?
 
 %w(a2ensite a2dissite a2enmod a2dismod a2enconf a2disconf).each do |modscript|
   template "/usr/sbin/#{modscript}" do


### PR DESCRIPTION
I have wrapper-cookbook with tests. Each time I run chefspec without providing platform cookbook fails, because node['apache']['perl_pkg'] is not set, but used.
