### PR TITLE
Allow to set LANG and LC_ALL in envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ the top of the file.
 * `node['apache']['lib_dir']` - Location for shared libraries
 * `node['apache']['default_site_enabled']` - Default site enabled. Default is false.
 * `node['apache']['ext_status']` - if true, enables ExtendedStatus for `mod_status`
+* `node['apache']['locale'] - Locale to set in envvars and used for subprocesses and modules (like mod_dav and mod_wsgi). Uses system-local if set to 'system', defaults to 'C'.
 
 General settings
 ----------------

--- a/templates/default/envvars.erb
+++ b/templates/default/envvars.erb
@@ -16,11 +16,15 @@ export APACHE_LOCK_DIR=<%= node['apache']['lock_dir'] %>
 export APACHE_LOG_DIR=<%= node['apache']['log_dir'] %>
 
 ## The locale used by some modules like mod_dav
-export LANG=C
+<%- if node['apache'].fetch('locale', 'C') != 'system' %>
+export LANG=<%= node['apache'].fetch('locale', 'C') %>
+export LC_ALL=<%= node['apache'].fetch('locale', 'C') %>
+<%- else %>
 ## Uncomment the following line to use the system default locale instead:
-#. /etc/default/locale
-
+. /etc/default/locale
 export LANG
+<%- end %>
+
 
 ## The command to get the status for 'apache2ctl status'.
 ## Some packages providing 'www-browser' need '--dump' instead of '-dump'.


### PR DESCRIPTION
Some apps/modules like mod_dav and mod_wsgi need the language to be set to specific values. Lets allow that through envvars (on debian systems only?).

This should be backward-compatible as 'C' remains the default. If a language is set, it is used, if the parameter is set to 'system', /etc/default/locale gets importet.
