### PR TITLE
Install package unless PHP is compiled from source.

### DIFF
--- a/attributes/mod_php5.rb
+++ b/attributes/mod_php5.rb
@@ -1,0 +1,19 @@
+#
+# Cookbook Name:: apache2
+# Attributes:: mod_php5
+#
+# Copyright 2012-2013, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+default['apache']['php_install_method'] = 'package'

--- a/recipes/mod_php5.rb
+++ b/recipes/mod_php5.rb
@@ -52,7 +52,7 @@ when 'freebsd'
   %w(php5 mod_php5 libxml2).each do |pkg|
     freebsd_package pkg
   end
-end
+end unless node['apache']['php_install_method'] == 'source'
 
 file "#{node['apache']['dir']}/conf.d/php.conf" do
   action :delete


### PR DESCRIPTION
This commit checks that php was not compiled from source in order to
prevent installing the php package over the compiled php.

This change allows for the use of the apache php configuration whether
or not one is using compiled or a packaged PHP.
