### PR TITLE
Explicitly include mod_ldap before mod_authnz_ldap

### DIFF
--- a/recipes/mod_authnz_ldap.rb
+++ b/recipes/mod_authnz_ldap.rb
@@ -17,4 +17,6 @@
 # limitations under the License.
 #
 
+include_recipe 'apache2::mod_ldap'
+
 apache_module 'authnz_ldap'


### PR DESCRIPTION
Fixes this error
[Tue Sep 09 10:40:20.589086 2014] [authnz_ldap:error] [pid 27819] AH01749: Module mod_ldap missing. Mod_ldap (aka. util_ldap) must be loaded in order for mod_authnz_ldap to function properly
