### PR TITLE
Use dpkg_package resource to install mod_pagespeed

### DIFF
--- a/recipes/mod_pagespeed.rb
+++ b/recipes/mod_pagespeed.rb
@@ -24,7 +24,7 @@ if platform_family?('debian')
     action :create_if_missing
   end
 
-  package 'mod_pagespeed' do
+  dpkg_package 'mod_pagespeed' do
     source "#{Chef::Config[:file_cache_path]}/mod-pagespeed.deb"
     action :install
   end


### PR DESCRIPTION
Using the `package` resource will default to `apt` and will error out with
`[2014-09-09T18:05:04+00:00] ERROR: package[mod_pagespeed]
(apache2::mod_pagespeed line 27) had an error:
Chef::Exceptions::Package: apt package provider cannot handle source
attribute. Use dpkg provider instead`
