### PR TITLE
Don't prepend Apache log path when requesting error logging to syslog

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -129,7 +129,11 @@ HostnameLookups Off
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
+<% if node['apache']['error_log'] =~ /^syslog:/ %>
+ErrorLog <%= node['apache']['error_log'] %>
+<% else %>
 ErrorLog <%= node['apache']['log_dir'] %>/<%= node['apache']['error_log'] %>
+<% end %>
 
 #
 # LogLevel: Control the number of messages logged to the error_log.


### PR DESCRIPTION
Currently it's not possible to set the log location to syslog as the apache directory is always prepended to the error_log attribute.
