### PR TITLE
Update mod_authn_core.rb

### DIFF
--- a/recipes/mod_authn_core.rb
+++ b/recipes/mod_authn_core.rb
@@ -19,5 +19,5 @@
 if node['apache']['version'] == '2.4'
   apache_module 'authn_core'
 else
-  log 'Ignoring apache2::mod_authn_core. not available until apache 2.4'
+  Chef::Log.info('Ignoring apache2::mod_authn_core. not available until apache 2.4')
 end


### PR DESCRIPTION
Using log resource is an anti-pattern as described in the link below as it creates converges that always contain "1/xyz resources converged" on every chef-client run.

http://www.getchef.com/blog/2013/09/04/demystifying-common-idioms-in-chef-recipes/
