### PR TITLE
[rubocop] Warning: Deprecated pattern style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   Exclude:
-    - vendor/**
-    - ruby/**
+    - vendor/**/*
+    - ruby/**/*
     - test/**/*
     - files/**/*
 


### PR DESCRIPTION
From Rubocop README

> Note: The pattern config/*\* will match any file recursively under config, but this pattern style is deprecated and should be replaced by config/*_/_.
