### PR TITLE
Disable SSLv3 protocol.

### DIFF
--- a/templates/default/mods/ssl.conf.erb
+++ b/templates/default/mods/ssl.conf.erb
@@ -90,7 +90,7 @@
 <% if node['apache']['version'] == '2.4' -%>
   SSLProtocol all -SSLv3
 <% else -%>
-  SSLProtocol all -SSLv2
+  SSLProtocol all -SSLv2 -SSLv3
 <% end -%>
 
   #   Allow insecure renegotiation with clients which do not yet support the


### PR DESCRIPTION
SSLv3 has a security vulnerability called "Poodle". The fix
disables SSLv3 at the apache level for infrastructures that do
not have the ability to disable it on the firewall or proxy.

[Fixes #283]
