### PR TITLE
FCGI paths should not be messed with on RHEL/CenOS 7.

### DIFF
--- a/recipes/mod_fcgid.rb
+++ b/recipes/mod_fcgid.rb
@@ -29,12 +29,15 @@ elsif platform_family?('rhel', 'fedora')
     backup false
   end
 
-  directory '/var/run/httpd/mod_fcgid' do
-    owner node['apache']['user']
-    group node['apache']['group']
-    recursive true
-    only_if { node['platform_version'].to_i >= 6 }
+  if ((node['platform_family'] == 'rhel') && (node['platform_version'].to_i == 6)) ||
+      ((node['platform_family'] == 'fedora') && (node['platform_version'].to_i < 20))
+    directory '/var/run/httpd/mod_fcgid' do
+      owner node['apache']['user']
+      group node['apache']['group']
+      recursive true
+    end
   end
+
 elsif platform_family?('suse')
   apache_lib_path = node['apache']['lib_dir']
 

--- a/templates/default/mods/fcgid.conf.erb
+++ b/templates/default/mods/fcgid.conf.erb
@@ -3,7 +3,8 @@
   IPCConnectTimeout 20
 </IfModule>
 
-<% if %w[rhel fedora].include?(node['platform_family']) -%>
+<% if ((node['platform_family'] == 'rhel') && (node['platform_version'].to_i == 6)) ||
+      ((node['platform_family'] == 'fedora') && (node['platform_version'].to_i < 20)) -%>
 # Sane place to put sockets and shared memory file
 SocketPath run/mod_fcgid
 SharememPath run/mod_fcgid/fcgid_shm


### PR DESCRIPTION
CentOS 7 (and recent Fedoras) have Apache 2.4, where FCGI socket path
and shared memory path is managed adequately without further involvment
neccessary (subdirectory is created under /var/run/httpd).

However, when the path is specified manually, that subdirectory is NOT
created automatically if it doesn't already exist and Apache fails to
start. Since in recent RHEL systems /var/run is on tmpfs, end result is
that chef-created subdirectory disappears on shutdown, and Apache fails
to start after server reboot. Best to leave out these two settings
unset then.
