### PR TITLE
Optional installation using definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ values are noted.
 * `node['apache']['sysconfig_additional_params']` - Additionals variables set in sysconfig file. Default is empty.
 * `node['apache']['default_modules']` - Array of module names. Can take "mod_FOO" or "FOO" as names, where FOO is the apache module, e.g. "`mod_status`" or "`status`".
 * `node['apache']['mpm']` - With apache.version 2.4, specifies what Multi-Processing Module to enable. Default is "prefork".
+* `node['apache']['definitions']['default_install`]` - Default true. If the definitions should call default recipe. Useful if you are installing and configuring apache separately.
+* `node['apache']['definitions']['web_app_install`]` - Default true. If the web_app definition should call default recipe. Useful if you are installing and configuring apache separately.
 
 The modules listed in `default_modules` will be included as recipes in `recipe[apache::default]`.
 
@@ -603,13 +605,15 @@ Manage a template resource for a VirtualHost site, and enable it with
 such as Ruby on Rails, PHP or Django, and the default behavior
 reflects that. However it is flexible.
 
-This definition includes some recipes to make sure the system is
-configured to have Apache and some sane default modules:
+This definition includes some recipes by default to make sure the system 
+is configured to have Apache and some sane default modules:
 
 * `apache2`
 * `apache2::mod_rewrite`
 * `apache2::mod_deflate`
 * `apache2::mod_headers`
+
+This feature can be disabled by overriding the default value definitions:web_app_install = true
 
 It will then configure the template (see __Parameters__ and
 __Examples__ below), and enable or disable the site per the `enable`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -331,6 +331,10 @@ default['apache']['default_modules'] = %w(
   authz_host authz_user autoindex dir env mime negotiation setenvif
 )
 
+# If the default apache2 script should be called from definitions
+default['apache']['definitions']['default_install'] = true
+default['apache']['definitions']['web_app_install'] = true
+
 %w(log_config logio).each do |log_mod|
   default['apache']['default_modules'] << log_mod if %w(rhel fedora suse arch freebsd).include?(node['platform_family'])
 end

--- a/definitions/apache_conf.rb
+++ b/definitions/apache_conf.rb
@@ -18,7 +18,10 @@
 #
 
 define :apache_conf, :enable => true do
-  include_recipe 'apache2::default'
+  if node['apache']['definitions']['default_install']
+    include_recipe 'apache2::default'
+  end
+  include_recipe 'apache2::_service_def'
 
   conf_name = "#{params[:name]}.conf"
   params[:conf_path] = params[:conf_path] || "#{node['apache']['dir']}/conf-available"

--- a/definitions/apache_config.rb
+++ b/definitions/apache_config.rb
@@ -18,7 +18,10 @@
 #
 
 define :apache_config, :enable => true do
-  include_recipe 'apache2::default'
+  if node['apache']['definitions']['default_install']
+    include_recipe 'apache2::default'
+  end
+  include_recipe 'apache2::_service_def'
 
   conf_name = "#{params[:name]}.conf"
   params[:conf_path] = params[:conf_path] || "#{node['apache']['dir']}/conf-available"

--- a/definitions/apache_mod.rb
+++ b/definitions/apache_mod.rb
@@ -18,7 +18,10 @@
 #
 
 define :apache_mod do
-  include_recipe 'apache2::default'
+  if node['apache']['definitions']['default_install']
+    include_recipe 'apache2::default'
+  end
+  include_recipe 'apache2::_service_def'
 
   template "#{node['apache']['dir']}/mods-available/#{params[:name]}.conf" do
     source "mods/#{params[:name]}.conf.erb"

--- a/definitions/apache_module.rb
+++ b/definitions/apache_module.rb
@@ -18,7 +18,11 @@
 #
 
 define :apache_module, :enable => true, :conf => false, :restart => false do
-  include_recipe 'apache2::default'
+  if node['apache']['definitions']['default_install']
+    include_recipe 'apache2::default'
+  end
+  include_recipe 'apache2::_service_def'
+
 
   params[:filename]    = params[:filename] || "mod_#{params[:name]}.so"
   params[:module_path] = params[:module_path] || "#{node['apache']['libexec_dir']}/#{params[:filename]}"

--- a/definitions/apache_site.rb
+++ b/definitions/apache_site.rb
@@ -18,7 +18,10 @@
 #
 
 define :apache_site, :enable => true do
-  include_recipe 'apache2::default'
+  if node['apache']['definitions']['default_install']
+    include_recipe 'apache2::default'
+  end
+  include_recipe 'apache2::_service_def'
   conf_name = "#{params[:name]}.conf"
 
   if params[:enable]

--- a/definitions/web_app.rb
+++ b/definitions/web_app.rb
@@ -20,10 +20,13 @@
 define :web_app, :template => 'web_app.conf.erb', :local => false, :enable => true do
   application_name = params[:name]
 
-  include_recipe 'apache2::default'
-  include_recipe 'apache2::mod_rewrite'
-  include_recipe 'apache2::mod_deflate'
-  include_recipe 'apache2::mod_headers'
+  if node['apache']['definitions']['web_app_install']
+    include_recipe 'apache2::default'
+    include_recipe 'apache2::mod_rewrite'
+    include_recipe 'apache2::mod_deflate'
+    include_recipe 'apache2::mod_headers'
+  end
+  include_recipe 'apache2::_service_def'
 
   template "#{node['apache']['dir']}/sites-available/#{application_name}.conf" do
     source params[:template]

--- a/recipes/_service_def.rb
+++ b/recipes/_service_def.rb
@@ -1,0 +1,14 @@
+service 'apache2' do
+  service_name node['apache']['service_name']
+  case node['platform_family']
+  when 'rhel'
+    reload_command '/sbin/service httpd graceful'
+  when 'debian'
+    provider Chef::Provider::Service::Debian
+  when 'arch'
+    service_name 'httpd'
+  end
+  supports [:start, :restart, :reload, :status]
+  action [:enable, :start]
+  only_if "#{node['apache']['binary']} -t", :environment => { 'APACHE_LOG_DIR' => node['apache']['log_dir'] }, :timeout => 10
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,9 @@ package 'apache2' do
   package_name node['apache']['package']
 end
 
+## include the shared service definition
+include_recipe 'apache2::_service_def'
+
 %w(sites-available sites-enabled mods-available mods-enabled conf-available conf-enabled).each do |dir|
   directory "#{node['apache']['dir']}/#{dir}" do
     mode '0755'
@@ -197,19 +200,4 @@ if node['apache']['default_site_enabled']
     template 'default-site.conf.erb'
     enable node['apache']['default_site_enabled']
   end
-end
-
-service 'apache2' do
-  service_name node['apache']['service_name']
-  case node['platform_family']
-  when 'rhel'
-    reload_command '/sbin/service httpd graceful'
-  when 'debian'
-    provider Chef::Provider::Service::Debian
-  when 'arch'
-    service_name 'httpd'
-  end
-  supports [:start, :restart, :reload, :status]
-  action [:enable, :start]
-  only_if "#{node['apache']['binary']} -t", :environment => { 'APACHE_LOG_DIR' => node['apache']['log_dir'] }, :timeout => 10
 end


### PR DESCRIPTION
I'm using this cookbook to install Apache and then configure multiple sites. When doing so, it re-runs the "default" recipe attempting to re-installing everything again.

I've created two new optional values which target this behaviour and allow it to be disabled - they are defaulted to true to continue backwards compatibility.

The service definition is split into a separate recipe to allow for inclusion within the definitions.
