### PR TITLE
Add default server name to the apache2.conf template

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -3,6 +3,7 @@
 #
 # Based on the Ubuntu apache2.conf
 
+ServerName "<%= node['apache']['server_name'] || node.name %>"
 ServerRoot "<%= node['apache']['dir'] %>"
 
 #


### PR DESCRIPTION
In my configuration, I am running with `apache httpd 2.2` on RHEL 6.6. In this configuration restarting the httpd service takes upward of 30 seconds due to the server name not being defined in the httpd.conf/apache2.conf file ultimately falling back on localhost for the default. However, due to this extended time taken trying to restart the httpd service the chef installation times out making it impossible to continue provisioning of the chef run. 

This PR adds the `ServerName` directive to the apache2.conf template thus allowing the httpd service to not spend so much time attempting to find the best suited `ServerName`. I've made it configurable based on the `node['apache']['server_name']` attribute and if that is not provided taking the node name instead.
