### PR TITLE
add node['apache']['mpm_support'] to general settings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ values are noted.
 * `node['apache']['sysconfig_additional_params']` - Additionals variables set in sysconfig file. Default is empty.
 * `node['apache']['default_modules']` - Array of module names. Can take "mod_FOO" or "FOO" as names, where FOO is the apache module, e.g. "`mod_status`" or "`status`".
 * `node['apache']['mpm']` - With apache.version 2.4, specifies what Multi-Processing Module to enable. Defaults to platform default, otherwise it is "prefork"
+* `node['apache']['mpm_support']` - Array of supported MPM modules to install. Default is prefork, worker and event.
 
 The modules listed in `default_modules` will be included as recipes in `recipe[apache::default]`.
 


### PR DESCRIPTION
No added functionality, just adding a line to the docs.

I was bitten by this: I was removing mpm_event using apache_module in a cookbook causing a race condition every chef run as it was installed again by the apache2 cookbook because of defaults on the next run. The attribute was defined in the attributes/default.rb but not documented. Added to documentation just to reduce the small amount of time it takes to resolve any future issues for others looking at the same thing.
