### PR TITLE
add variable module support to web_app definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Current parameters used by the definition:
   cookbook where the definition is used.
 * `template` - Default `web_app.conf.erb`, source template file.
 * `enable` - Default true. Passed to the `apache_site` definition.
+* `modules` - Default `%w(rewrite deflate headers)`. Passed to the `apache_site` definition. Unscoped module names default to `apache2::` recipes. Additional modules can be loaded with `wrapper-cookbook::module`.
 
 Additional parameters can be defined when the definition is called in
 a recipe, see __Examples__.

--- a/definitions/web_app.rb
+++ b/definitions/web_app.rb
@@ -17,13 +17,19 @@
 # limitations under the License.
 #
 
-define :web_app, :template => 'web_app.conf.erb', :local => false, :enable => true, :server_port => 80 do
+define :web_app, :template => 'web_app.conf.erb', :local => false, :enable => true, :server_port => 80, :modules => %w(rewrite deflate headers) do
   application_name = params[:name]
 
   include_recipe 'apache2::default'
-  include_recipe 'apache2::mod_rewrite'
-  include_recipe 'apache2::mod_deflate'
-  include_recipe 'apache2::mod_headers'
+  params[:modules].each do |name|
+    if name.include? '::'
+      include_recipe name
+    elsif name.start_with? 'mod_'
+      include_recipe "apache2::#{name}"
+    else
+      include_recipe "apache2::mod_#{name}"
+    end
+  end
 
   template "#{node['apache']['dir']}/sites-available/#{application_name}.conf" do
     source params[:template]


### PR DESCRIPTION
This patch allows a `web_app` user to specify the modules loaded with the application instead of forcing the hardcoded list. Supports `mod_` and `mod_modname` references, as well as `wrapper-cookbook::module_name`.
