### PR TITLE
Do not enable alias.conf. Only link alias.load

### DIFF
--- a/recipes/mod_alias.rb
+++ b/recipes/mod_alias.rb
@@ -18,5 +18,5 @@
 #
 
 apache_module 'alias' do
-  conf true
+  conf false
 end


### PR DESCRIPTION
mod_alias is enabled by default. It links both the alias.load and alias.conf

Alias.conf contains the following:

```
<IfModule alias_module>
  #
  # Aliases: Add here as many aliases as you need (with no limit). The format is
  # Alias fakename realname
  #
  # Note that if you include a trailing / on fakename then the server will
  # require it to be present in the URL.  So "/icons" isn't aliased in this
  # example, only "/icons/".  If the fakename is slash-terminated, then the
  # realname must also be slash terminated, and if the fakename omits the
  # trailing slash, the realname must also omit it.
  #
  # We include the /icons/ alias for FancyIndexed directory listings.  If
  # you do not use FancyIndexing, you may comment this out.
  #
  Alias /icons/ "/usr/share/apache2/icons/"

  <Directory "/usr/share/apache2/icons">
    Options Indexes MultiViews
    AllowOverride None
    Order allow,deny
    Allow from all
  </Directory>
</IfModule>
```

If you append /icons/ to any domain running this cookbook, you will get a directory listing with icons:

![screen shot 2016-07-25 at 13 29 22](https://cloud.githubusercontent.com/assets/242967/17100030/4b4a6608-526c-11e6-87a0-bd21d8b53d8f.png)

Not only is this a useless feature, but it's also a security vulnerability: http://www.acunetix.com/blog/articles/directory-listing-information-disclosure/
