### PR TITLE
Update Berksfile to allow fetching of newer

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,11 +3,11 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
-  cookbook 'apt', '~> 5.0.0'
+  cookbook 'apt'
   cookbook 'fqdn', git: 'https://github.com/drpebcak/fqdn-cookbook.git'
-  cookbook 'pacman', '~> 1.1.1'
-  cookbook 'yum', '~> 4.1.0'
-  cookbook 'zypper', '~> 0.3.0'
+  cookbook 'pacman'
+  cookbook 'yum'
+  cookbook 'zypper'
 end
 
 cookbook 'apache2_test', path: 'test/cookbooks/apache2_test'


### PR DESCRIPTION
non-error-deprecating-spewing cookbooks

## Description

Update Berksfile

### Issues Resolved

Partially fixes #468 

### Check List
- [ ] All tests pass. See https://github.com/chef-brigade/apache2/blob/master/TESTING.md

