### PR TITLE
Use a SPDX standard license string

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ issues_url 'https://github.com/sous-chefs/apache2/issues' if respond_to?(:issues
 maintainer 'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
 chef_version '>= 11' if respond_to?(:chef_version)
-license 'Apache 2.0'
+license 'Apache-2.0'
 description 'Installs and configures all aspects of apache2 using Debian style symlinks with helper definitions'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '3.3.0'


### PR DESCRIPTION
Resolves Foodcritic warnings

Signed-off-by: Tim Smith <tsmith@chef.io>