### PR TITLE
Include mod_cache in modules that require it

### DIFF
--- a/recipes/mod_cache_disk.rb
+++ b/recipes/mod_cache_disk.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include_recipe 'apache2::mod_cache'
+
 apache_module 'cache_disk' do
   conf true
 end

--- a/recipes/mod_cache_socache.rb
+++ b/recipes/mod_cache_socache.rb
@@ -17,4 +17,6 @@
 # limitations under the License.
 #
 
+include_recipe 'apache2::mod_cache'
+
 apache_module 'cache_socache'


### PR DESCRIPTION
In Debian, this is done with a `# Depends` comment that `a2enmod` follows.

The cookbook replicates these dependencies via recipe inclusion. This set of dependencies was missing.