### PR TITLE
Allow APACHE_STATUSURL to be configured

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -291,6 +291,9 @@ default['apache']['traceenable']     = 'Off'
 # mod_status Allow list, space seprated list of allowed entries.
 default['apache']['status_allow_list'] = '127.0.0.1 ::1'
 
+# URL used by apache2ctl status
+default['apache']['status_url'] = 'http://localhost:80/server-status'
+
 # mod_status ExtendedStatus, set to 'true' to enable
 default['apache']['ext_status'] = false
 

--- a/templates/default/envvars.erb
+++ b/templates/default/envvars.erb
@@ -41,3 +41,5 @@ export LANG
 ## This will produce a verbose output on package installations of web server modules and web application
 ## installations which interact with Apache
 #export APACHE2_MAINTSCRIPT_DEBUG=1
+
+APACHE_STATUSURL=<%= node['apache']['status_url'] %>


### PR DESCRIPTION
Probably a rare use case, but we configure our mod_status on a non-standard vhost, that requires customising `APACHE_STATUSURL`, for `apache2ctl status` to work.