### PR TITLE
Sysconfig issue486

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -133,7 +133,7 @@ directory node['apache']['lock_dir'] do
 end
 
 # Set the preferred execution binary - prefork or worker
-template "/etc/sysconfig/#{node['apache']['ervice_name']}" do
+template "/etc/sysconfig/#{node['apache']['service_name']}" do
   source 'etc-sysconfig-httpd.erb'
   owner 'root'
   group node['apache']['root_group']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -133,7 +133,7 @@ directory node['apache']['lock_dir'] do
 end
 
 # Set the preferred execution binary - prefork or worker
-template "/etc/sysconfig/#{node['apache']['package']}" do
+template "/etc/sysconfig/#{node['apache']['ervice_name']}" do
   source 'etc-sysconfig-httpd.erb'
   owner 'root'
   group node['apache']['root_group']

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -181,34 +181,34 @@ describe 'apache2::default' do
           end
 
           if %w(amazon redhat centos fedora suse opensuse).include?(platform)
-            it "creates /etc/sysconfig/#{property[:apache][:package]}" do
-              expect(chef_run).to create_template("/etc/sysconfig/#{property[:apache][:package]}").with(
+            it "creates /etc/sysconfig/#{property[:apache]['service_name']}" do
+              expect(chef_run).to create_template("/etc/sysconfig/#{property[:apache]['service_name']}").with(
                 source: 'etc-sysconfig-httpd.erb',
                 owner: 'root',
                 group: property[:apache][:root_group],
                 mode: '0644'
               )
 
-              expect(chef_run).to render_file("/etc/sysconfig/#{property[:apache][:package]}").with_content(
+              expect(chef_run).to render_file("/etc/sysconfig/#{property[:apache]['service_name']}").with_content(
                 /HTTPD=#{property[:apache][:binary]}/
               )
             end
 
-            subject(:sysconfig) { chef_run.template("/etc/sysconfig/#{property[:apache][:package]}") }
-            it "notification is triggered by /etc/sysconfig/#{property[:apache][:package]} template to restart service[apache2]" do
+            subject(:sysconfig) { chef_run.template("/etc/sysconfig/#{property[:apache]['service_name']}") }
+            it "notification is triggered by /etc/sysconfig/#{property[:apache]['service_name']} template to restart service[apache2]" do
               expect(sysconfig).to notify('service[apache2]').to(:restart).delayed
               expect(sysconfig).to_not notify('service[apache2]').to(:restart).immediately
             end
           else
-            it "does not create /etc/sysconfig/#{property[:apache][:package]}" do
-              expect(chef_run).to_not create_template("/etc/sysconfig/#{property[:apache][:package]}").with(
+            it "does not create /etc/sysconfig/#{property[:apache]['service_name']}" do
+              expect(chef_run).to_not create_template("/etc/sysconfig/#{property[:apache]['service_name']}").with(
                 source: 'etc-sysconfig-httpd.erb',
                 owner: 'root',
                 group: property[:apache][:root_group],
                 mode: '0644'
               )
 
-              expect(chef_run).to_not render_file("/etc/sysconfig/#{property[:apache][:package]}").with_content(
+              expect(chef_run).to_not render_file("/etc/sysconfig/#{property[:apache]['service_name']}").with_content(
                 /#HTTPD_LANG=C/
               )
             end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -181,34 +181,34 @@ describe 'apache2::default' do
           end
 
           if %w(amazon redhat centos fedora suse opensuse).include?(platform)
-            it "creates /etc/sysconfig/#{property[:apache]['service_name']}" do
-              expect(chef_run).to create_template("/etc/sysconfig/#{property[:apache]['service_name']}").with(
+            it "creates /etc/sysconfig/#{property[:apache][:service_name]}" do
+              expect(chef_run).to create_template("/etc/sysconfig/#{property[:apache][:service_name]}").with(
                 source: 'etc-sysconfig-httpd.erb',
                 owner: 'root',
                 group: property[:apache][:root_group],
                 mode: '0644'
               )
 
-              expect(chef_run).to render_file("/etc/sysconfig/#{property[:apache]['service_name']}").with_content(
+              expect(chef_run).to render_file("/etc/sysconfig/#{property[:apache][:service_name]}").with_content(
                 /HTTPD=#{property[:apache][:binary]}/
               )
             end
 
-            subject(:sysconfig) { chef_run.template("/etc/sysconfig/#{property[:apache]['service_name']}") }
-            it "notification is triggered by /etc/sysconfig/#{property[:apache]['service_name']} template to restart service[apache2]" do
+            subject(:sysconfig) { chef_run.template("/etc/sysconfig/#{property[:apache][:service_name]}") }
+            it "notification is triggered by /etc/sysconfig/#{property[:apache][:service_name]} template to restart service[apache2]" do
               expect(sysconfig).to notify('service[apache2]').to(:restart).delayed
               expect(sysconfig).to_not notify('service[apache2]').to(:restart).immediately
             end
           else
-            it "does not create /etc/sysconfig/#{property[:apache]['service_name']}" do
-              expect(chef_run).to_not create_template("/etc/sysconfig/#{property[:apache]['service_name']}").with(
+            it "does not create /etc/sysconfig/#{property[:apache][:service_name]}" do
+              expect(chef_run).to_not create_template("/etc/sysconfig/#{property[:apache][:service_name]}").with(
                 source: 'etc-sysconfig-httpd.erb',
                 owner: 'root',
                 group: property[:apache][:root_group],
                 mode: '0644'
               )
 
-              expect(chef_run).to_not render_file("/etc/sysconfig/#{property[:apache]['service_name']}").with_content(
+              expect(chef_run).to_not render_file("/etc/sysconfig/#{property[:apache][:service_name]}").with_content(
                 /#HTTPD_LANG=C/
               )
             end


### PR DESCRIPTION
## Description

When cookbook is configured to install httpd24 package wrong config file is generated

The generated is 
   /etc/sysconfig/httpd24
Instead of 
  /etc/sysconfig/httpd

### Issues Resolved - #486 




