### PR TITLE
`mod_php5` -> `mod_php`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Installs the fcgi package and enables the module. Requires EPEL on RHEL family.
 
 Simply installs the appropriate package and enables the module
 
-- `node['apache']['mod_php5']['install_method']` - default `package` can be overridden to avoid package installs.
+- `node['apache']['mod_php']['install_method']` - default `package` can be overridden to avoid package installs.
 
 ## mod_ssl
 

--- a/attributes/mod_php.rb
+++ b/attributes/mod_php.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: apache2
-# Attributes:: mod_php5
+# Attributes:: mod_php
 #
 # Copyright:: 2014, Viverae, Inc.
 #

--- a/recipes/mod_php.rb
+++ b/recipes/mod_php.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: apache2
-# Recipe:: mod_php5
+# Recipe:: mod_php
 #
 # Copyright:: 2008-2017, Chef Software, Inc.
 # Copyright:: 2014, OneHealth Solutions, Inc.

--- a/test/cookbooks/apache2_test/README.md
+++ b/test/cookbooks/apache2_test/README.md
@@ -56,7 +56,7 @@ Recipes
 * `mod_dav_svn` - Adds a web_app with an empty Subversion repository for testing.
 * `mod_expires` - Adds a web_app that sets caching expiry headers for testing.
 * `mod_perl` - Adds a Perl script running under mod_perl that prints environment variables for testing.
-* `mod_php5` - Adds a PHP script running under mod_php5 that prints environment variables for testing.
+* `mod_php` - Adds a PHP script running under mod_php5 that prints environment variables for testing.
 * `mod_proxy_ajp` - Installs Tomcat with examples and configures proxying over AJP.
 * `mod_python` - Adds a Python script running under mod_python that prints environment variables for testing.
 * `mod_ssl` - Adds a self-signed SSL certificate and default website for testing.

--- a/test/cookbooks/apache2_test/metadata.rb
+++ b/test/cookbooks/apache2_test/metadata.rb
@@ -25,7 +25,7 @@ recipe           'apache2_test::mod_expires', 'Test example for setting cache ex
 recipe           'apache2_test::mod_dav_svn', 'Test example for Subversion repository hosting'
 recipe           'apache2_test::mod_perl', 'Test example for hosting a Perl application'
 recipe           'apache2_test::mod_proxy_ajp', 'Test example for proxying requests to a Java application'
-recipe           'apache2_test::mod_php5', 'Test example for hosting a PHP application'
+recipe           'apache2_test::mod_php', 'Test example for hosting a PHP application'
 recipe           'apache2_test::mod_python', 'Test example for hosting a Python application'
 recipe           'apache2_test::mod_ssl', 'Test example for SSL'
 recipe           'apache2_test::mod_status_remote', 'Test example for viewing server status'

--- a/test/cookbooks/apache2_test/recipes/mod_php.rb
+++ b/test/cookbooks/apache2_test/recipes/mod_php.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: apache2_test
-# Recipe:: mod_php5
+# Recipe:: mod_php
 #
 # Copyright:: 2012, Chef Software, Inc.
 #


### PR DESCRIPTION
documentation, tests, and comments not updated to reflect the change in recipe/configuration name from PHP5->7 where available

Signed-off-by: terry chay <terry@raise.me>

## Description

Mostly just a purge of `mod_php5` where it was missed

### Issues Resolved

- documentation inconsistency for configuration
- chef tests probably do not run correctly

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
