### PR TITLE
Fix mod_dav_svn on Debian 9

### DIFF
--- a/recipes/mod_dav_svn.rb
+++ b/recipes/mod_dav_svn.rb
@@ -24,7 +24,11 @@ package 'libapache2-svn' do
   when 'rhel', 'fedora', 'suse', 'amazon'
     package_name 'mod_dav_svn'
   else
-    package_name 'libapache2-svn'
+    if platform?('debian') && node['platform_version'].to_i >= 8
+      package_name 'libapache2-mod-svn'
+    else
+      package_name 'libapache2-svn'
+    end
   end
 end
 


### PR DESCRIPTION
In Debian 8 a transitional package was introduced and the old package was removed in Debian 9. Lets use the correct package on Debian 8+

Signed-off-by: Tim Smith <tsmith@chef.io>