### PR TITLE
Match mod_php .conf to module name

### DIFF
--- a/recipes/mod_php.rb
+++ b/recipes/mod_php.rb
@@ -71,7 +71,7 @@ when 'rhel', 'fedora', 'suse', 'amazon'
   end
 end
 
-template "#{node['apache']['dir']}/mods-available/php.conf" do
+template "#{node['apache']['dir']}/mods-available/#{node['apache']['mod_php']['module_name']}.conf" do
   source 'mods/php.conf.erb'
   mode '0644'
   notifies :reload, 'service[apache2]', :delayed


### PR DESCRIPTION
Since the apache module name is php5 and the module configuration is deployed as php.conf, enabling the php5 module does not also enable the appropriate configuration. This results in apache not properly displaying and executing .php files since various important configuration items are missing (including the .php extension handler).

This behavior was seen on CentOS 7. The incorrect file is also managed by Chef on Ubuntu but the libapache2-mod-php5 package there includes a php5.conf file so it all appeared to be working.

This pull request matches the mod_php configuration filename to the module name specified in the cookbook attributes.