### PR TITLE
more reliable MPM installation on SUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This cookbook uses many attributes, broken up into a few different kinds.
 
 In order to support the broadest number of platforms, several attributes are determined based on the node's platform. See the attributes/default.rb file for default values in the case statement at the top of the file.
 
-- `node['apache']['package']` - Package name for Apache2
+- `node['apache']['package']` - Package name for Apache2, ignored on (open)suse
 - `node['apache']['perl_pkg']` - Package name for Perl
 - `node['apache']['dir']` - Location for the Apache configuration
 - `node['apache']['log_dir']` - Location for Apache logs

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,7 +62,7 @@ when 'rhel', 'fedora', 'amazon'
   default['apache']['lib_dir'] = node['kernel']['machine'] =~ /^i[36]86$/ ? '/usr/lib/httpd' : '/usr/lib64/httpd'
   default['apache']['libexec_dir'] = "#{node['apache']['lib_dir']}/modules"
 when 'suse'
-  default['apache']['package']     = 'apache2'
+  default['apache']['service_name'] = 'apache2'
   default['apache']['perl_pkg']    = 'perl'
   default['apache']['devel_package'] = 'httpd-devel'
   default['apache']['apachectl']   = '/usr/sbin/apache2ctl'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 #
 
 package 'apache2' do # ~FC009 only available in apt_package. See #388
-  package_name node['apache']['package']
+  package_name platform_family?('suse') ? "apache2-#{node['apache']['mpm']}" : node['apache']['package']
   default_release node['apache']['default_release'] unless node['apache']['default_release'].nil?
 end
 

--- a/recipes/mpm_event.rb
+++ b/recipes/mpm_event.rb
@@ -19,11 +19,17 @@
 
 # OpenSuse distributes packages with workers compiled into the httpd bin
 if platform_family?('suse')
-  package %w(apache2-prefork apache2-worker) do
-    action :remove
+  %w(apache2-prefork apache2-worker).each do |pkg|
+    rpm_package pkg do
+      action :remove
+      notifies :restart, 'service[apache2]', :delayed
+    end
   end
 
-  package 'apache2-event'
+  link '/usr/sbin/httpd' do
+    to '/usr/sbin/httpd-event'
+    notifies :restart, 'service[apache2]', :delayed
+  end
 else
   # apache_module('mpm_itk') { enable false }
   apache_module('mpm_prefork') { enable false }

--- a/recipes/mpm_prefork.rb
+++ b/recipes/mpm_prefork.rb
@@ -19,11 +19,17 @@
 
 # OpenSuse distributes packages with workers compiled into the httpd bin
 if platform_family?('suse')
-  package %w(apache2-event apache2-worker) do
-    action :remove
+  %w(apache2-event apache2-worker).each do |pkg|
+    rpm_package pkg do
+      action :remove
+      notifies :restart, 'service[apache2]', :delayed
+    end
   end
 
-  package 'apache2-prefork'
+  link '/usr/sbin/httpd' do
+    to '/usr/sbin/httpd-prefork'
+    notifies :restart, 'service[apache2]', :delayed
+  end
 else
   # apache_module('mpm_itk') { enable false }
   apache_module('mpm_event') { enable false }

--- a/recipes/mpm_worker.rb
+++ b/recipes/mpm_worker.rb
@@ -19,11 +19,17 @@
 
 # OpenSuse distributes packages with workers compiled into the httpd bin
 if platform_family?('suse')
-  package %w(apache2-event apache2-prefork) do
-    action :remove
+  %w(apache2-event apache2-prefork).each do |pkg|
+    rpm_package pkg do
+      action :remove
+      notifies :restart, 'service[apache2]', :delayed
+    end
   end
 
-  package 'apache2-worker'
+  link '/usr/sbin/httpd' do
+    to '/usr/sbin/httpd-worker'
+    notifies :restart, 'service[apache2]', :delayed
+  end
 else
   # apache_module('mpm_itk') { enable false }
   apache_module('mpm_event') { enable false }

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -22,8 +22,9 @@ describe 'apache2::default' do
             @chef_run.converge(described_recipe)
           end
 
-          it "installs package #{property[:apache][:package]}" do
-            expect(chef_run).to install_package(property[:apache][:package])
+          it "installs package apache2" do
+            package = platform == 'opensuse' ? "apache2-#{property[:apache][:mpm]}" : property[:apache][:package]
+            expect(chef_run).to install_package(package)
           end
 
           it "creates #{property[:apache][:log_dir]} directory" do

--- a/spec/support/supported_platforms.rb
+++ b/spec/support/supported_platforms.rb
@@ -6,7 +6,7 @@ def supported_platforms
     'debian' => ['8.9'],
     'fedora' => %w(26),
     'redhat' => ['7.2'],
-    'centos' => ['7.3.1611'],
+    'centos' => ['7.4.1708'],
     'freebsd' => ['10.3'],
     'opensuse' => ['42.3'],
   }

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -18,8 +18,9 @@
 property = JSON.parse(inspec.profile.file("#{inspec.os.name}_#{inspec.os.release}.json"), symbolize_names: true)
 
 describe 'apache2::default' do
-  it "package #{property[:apache][:package]} is installed" do
-    expect(package(property[:apache][:package])).to be_installed
+  it "package apache2 is installed" do
+    pkg = inspec.os[:family] == 'suse' ? "apache2-#{property[:apache][:mpm]}" : property[:apache][:package]
+    expect(package(pkg)).to be_installed
   end
 
   it "service #{property[:apache][:service_name]} is enabled and running" do

--- a/test/integration/default/files/opensuse_42.3.json
+++ b/test/integration/default/files/opensuse_42.3.json
@@ -1,6 +1,5 @@
 {
     "apache": {
-        "package": "apache2",
         "devel_package": "httpd-devel",
         "binary": "/usr/sbin/httpd",
         "mpm": "prefork",


### PR DESCRIPTION
## Description

In (Open)SUSE it's possible to install different MPM packages but switching between them is very unreliable. By default prefork variant is installed but if install later worker prefork will be used still and if you remove prefork package you'll have a dangling symlink `/usr/sbin/httpd -> /usr/sbin/httpd-prefork`. This is exactly what you have with this cookbook if you don't want prefork MPM.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [~] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [+] New functionality includes testing.
- [+] New functionality has been documented in the README if applicable
