### PR TITLE
Return chef 11 support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,8 @@
 name 'apache2'
-source_url 'https://github.com/sous-chefs/apache2'
-issues_url 'https://github.com/sous-chefs/apache2/issues'
+source_url 'https://github.com/sous-chefs/apache2' if respond_to?(:source_url)
+issues_url 'https://github.com/sous-chefs/apache2/issues' if respond_to?(:issues_url)
 maintainer 'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
-chef_version '>= 12.1' if respond_to?(:chef_version)
 license 'Apache-2.0'
 description 'Installs and configures all aspects of apache2 using Debian style symlinks with helper definitions'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))


### PR DESCRIPTION
## Description

Some enterprises still use chef 11, this PR partially returns its support, bits not covered with it are the matter of #518 (packages removal on suse).

### Issues Resolved



### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
