### PR TITLE
Detect 64-bit architectures (fixes #529)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,19 @@
 # limitations under the License.
 #
 
+# Gets the libdir for a given CPU architecture
+def lib_dir_for_machine(arch)
+  if arch =~ /64/ || %w(armv8l s390x).include?(arch)
+    # 64-bit architectures
+    # (x86_64 / amd64 / aarch64 / armv8l / etc.)
+    '/usr/lib64'
+  else
+    # 32-bit architectures
+    # (i686 / armv7l / s390 / etc.)
+    '/usr/lib'
+  end
+end
+
 default['apache']['mpm'] =
   case node['platform']
   when 'ubuntu', 'linuxmint'
@@ -59,7 +72,7 @@ when 'rhel', 'fedora', 'amazon'
   default['apache']['run_dir']     = '/var/run/httpd'
   default['apache']['lock_dir']    = '/var/run/httpd'
   default['apache']['pid_file']    = '/var/run/httpd/httpd.pid'
-  default['apache']['lib_dir'] = node['kernel']['machine'] =~ /^i[36]86$/ ? '/usr/lib/httpd' : '/usr/lib64/httpd'
+  default['apache']['lib_dir'] = "#{lib_dir_for_machine(node['kernel']['machine'])}/httpd"
   default['apache']['libexec_dir'] = "#{node['apache']['lib_dir']}/modules"
 when 'suse'
   default['apache']['package']     = 'apache2'
@@ -81,7 +94,7 @@ when 'suse'
   default['apache']['run_dir']     = '/var/run/httpd'
   default['apache']['lock_dir']    = '/var/run/httpd'
   default['apache']['pid_file']    = '/var/run/httpd2.pid'
-  default['apache']['lib_dir']     = node['kernel']['machine'] =~ /^i[36]86$/ ? '/usr/lib/apache2' : '/usr/lib64/apache2'
+  default['apache']['lib_dir'] = "#{lib_dir_for_machine(node['kernel']['machine'])}/apache2"
   default['apache']['libexec_dir'] = node['apache']['lib_dir']
 when 'debian'
   default['apache']['package']     = 'apache2'

--- a/attributes/mod_pagespeed.rb
+++ b/attributes/mod_pagespeed.rb
@@ -18,6 +18,7 @@
 #
 
 default['apache2']['mod_pagespeed']['package_link'] =
+  # NOTE: no precompiled packages for other architectures
   if node['kernel']['machine'] =~ /^i[36']86$/
     'https://dl-ssl.google.com/dl/linux/direct/mod-pagespeed-stable_current_i386.deb'
   else


### PR DESCRIPTION
## Description
The current behavior on RHEL and compatibles is to assume a machine is 64-bit unless a regex for i386/i686 is matched. This causes alternative architectures (e.g. 32-bit ARM) to be misdetected as 64-bit.

This change attempts to better detect 64-bit architectures:
* Any machine type including "64" is assumed to be 64-bit. This is generally the case for supported architectures, e.g. "x86_64", "aarch64", "ppc64", etc.
* Some known 64-bit machine types without "64" are explicitly matched, e.g. "armv8l", "s390x".
* Anything else is assumed to be 32-bit (e.g. i686, armv7l)

### Issues Resolved

#529 (32-bit ARM is flagged as a 64-bit architecture)

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
I ran an abbreviated set of tests against CentOS (as this covers the RHEL/Fedora/Amazon platform code path). I did not test the SuSE path as there is no Test Kitchen profile for it. I additionally tested against CentOS on an armv7l box.
- [x] New functionality includes testing.
I have not added tests for the new non-x86_64 cases.
- [x] New functionality has been documented in the README if applicable
No new functionality is included.
