### PR TITLE
Update apache2.conf.erb

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -40,10 +40,10 @@ MaxKeepAliveRequests <%= node['apache']['keepaliverequests'] %>
 #
 KeepAliveTimeout <%= node['apache']['keepalivetimeout'] %>
 
-#<IfModule unixd_module>
-User <%= node['apache']['user'] %>
-Group <%= node['apache']['group'] %>
-#</IfModule>
+<IfModule unixd_module>
+  User <%= node['apache']['user'] %>
+  Group <%= node['apache']['group'] %>
+</IfModule>
 
 # Sets the default security model of the Apache2 HTTPD server. It does
 # not allow access to the root filesystem outside of /usr/share and <%= node['apache']['docroot_dir'] %>.
@@ -66,6 +66,8 @@ Group <%= node['apache']['group'] %>
         AllowOverride None
         Require all granted
 </Directory>
+
+DocumentRoot <%= node['apache']['docroot_dir'] %>
 
 <Directory <%= node['apache']['docroot_dir'] %>>
         Options Indexes FollowSymLinks


### PR DESCRIPTION
Uncomment conditionals around User and Group statements - as they are undefined without the module unixd loaded. In addition, define DocumentRoot to match the attribute node['apache']['docroot_dir']. This means the server will come up in a working configuration.

## Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
