### PR TITLE
Drop support for chef-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the apache2 cookbook.
 
+## v6.0.0 (tbc)
+
+- Drop Chef 12 support
+
 ## v5.0.1 (2017-09-01)
 
 - Test using dokken-images in kitchen-dokken

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,9 +3,9 @@ source_url 'https://github.com/sous-chefs/apache2'
 issues_url 'https://github.com/sous-chefs/apache2/issues'
 maintainer 'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
-chef_version '>= 12.1' if respond_to?(:chef_version)
+chef_version '>= 13.0'
 license 'Apache-2.0'
-description 'Installs and configures all aspects of apache2 using Debian style symlinks with helper definitions'
+description 'Installs and configures apache2'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '5.0.1'
 


### PR DESCRIPTION
## Description

Drop Chef 12 support now it's EOL

### Check List
- [ ] New functionality has been documented in the README if applicable
