### PR TITLE
Update Test kitchen configuration

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -40,16 +40,16 @@ platforms:
     image: dokken/fedora-latest
     pid_one_command: /usr/lib/systemd/systemd
 
-- name: ubuntu-14.04
-  driver:
-    image: dokken/ubuntu-14.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-
 - name: ubuntu-16.04
   driver:
     image: dokken/ubuntu-16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
+- name: ubuntu-18.04
+  driver:
+    image: dokken/ubuntu-18.04
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
@@ -58,86 +58,3 @@ platforms:
   driver:
     image: dokken/opensuse-leap
     pid_one_command: /bin/systemd
-
-suites:
-  - name: default
-    run_list:
-    - recipe[apache2_test::setup]
-    - recipe[apache2_test::default]
-    - recipe[apache2_test::basic_web_app]
-    - recipe[apache2_test::broken_conf]
-    - recipe[apache2_test::modules]
-    - recipe[apache2_test::mod_ssl]
-    - recipe[apache2_test::mod_auth_basic]
-    - recipe[apache2_test::mod_auth_digest]
-  # - recipe[apache2_test::mod_auth_openid]
-  # - recipe[apache2_test::mod_authnz_ldap]
-    - recipe[apache2_test::mod_authz_groupfile]
-    - recipe[apache2_test::mod_authz_listed_host]
-    - recipe[apache2_test::mod_authz_unlisted_host]
-    - recipe[apache2_test::mod_authz_user]
-    - recipe[apache2_test::mod_cgi]
-  # not supported by apache 2.4 without source compile with non-maintainer patches
-  # - recipe[apache2_test::mod_fastcgi]
-  # - recipe[apache2_test::mod_dav_svn]
-    - recipe[apache2_test::mod_expires]
-    - recipe[apache2_test::mod_status_remote]
-
-  - name: prefork
-    run_list:
-    - recipe[apache2_test::setup]
-    - recipe[apache2_test::default]
-    - recipe[apache2_test::broken_conf]
-    - recipe[apache2_test::modules]
-    - recipe[apache2_test::mod_cgi]
-  #  - recipe[apache2_test::mod_fastcgi]
-    - recipe[apache2_test::mod_perl]
-    - recipe[apache2_test::mod_php]
-  # - recipe[apache2_test::mod_proxy_ajp]
-    - recipe[apache2_test::mod_python]
-    - recipe[apache2_test::mod_ssl]
-    attributes:
-      apache:
-        mpm: prefork
-    verifier:
-      inspec_tests:
-        - test/integration/default
-    includes: [
-      'centos-7',
-      'ubuntu-14.04',
-      'ubuntu-16.04'
-      ]
-
-  - name: worker
-    run_list:
-    - recipe[apache2_test::setup]
-    - recipe[apache2_test::default]
-    - recipe[apache2_test::basic_web_app]
-    - recipe[apache2_test::broken_conf]
-    - recipe[apache2_test::modules]
-    attributes:
-      apache:
-        mpm: worker
-    verifier:
-      inspec_tests:
-        - test/integration/default
-    includes: [
-      'centos-7'
-      ]
-
-  - name: event
-    run_list:
-    - recipe[apache2_test::setup]
-    - recipe[apache2_test::default]
-    - recipe[apache2_test::basic_web_app]
-    - recipe[apache2_test::broken_conf]
-    - recipe[apache2_test::modules]
-    attributes:
-      apache:
-        mpm: event
-    verifier:
-      inspec_tests:
-        - test/integration/default
-    includes: [
-      'ubuntu-16.04'
-      ]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -80,10 +80,10 @@ suites:
       apache:
         mpm: prefork
     includes:
-      - 'centos-7'
-      - 'debian-8'
-      - 'ubuntu-16.04'
-      - 'ubuntu-18.04'
+      - centos-7
+      - debian-8
+      - ubuntu-16.04
+      - ubuntu-18.04
 
   - name: worker
     run_list:
@@ -99,8 +99,8 @@ suites:
       apache:
         mpm: worker
     includes:
-      - 'centos-7'
-      - 'ubuntu-16.04'
+      - centos-7
+      - ubuntu-16.04
 
   - name: event
     run_list:
@@ -119,4 +119,4 @@ suites:
       inspec_tests:
         - test/integration/default
     includes:
-      - 'ubuntu-16.04'
+      - ubuntu-16.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -79,12 +79,11 @@ suites:
       machine_fqdn_as_hostname: true
       apache:
         mpm: prefork
-    includes: [
-      'centos-7',
-      'debian-8',
-      'ubuntu-16.04',
-      'ubuntu-18.04'
-      ]
+    includes:
+      - 'centos-7'
+      - 'debian-8'
+      - 'ubuntu-16.04'
+      - 'ubuntu-18.04'
 
   - name: worker
     run_list:
@@ -99,10 +98,9 @@ suites:
       machine_fqdn_as_hostname: true
       apache:
         mpm: worker
-    includes: [
-      'centos-7',
-      'ubuntu-16.04'
-      ]
+    includes:
+      - 'centos-7'
+      - 'ubuntu-16.04'
 
   - name: event
     run_list:
@@ -120,6 +118,5 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/default
-    includes: [
-      'ubuntu-16.04'
-      ]
+    includes:
+      - 'ubuntu-16.04'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,12 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: <%= ENV['CHEF_VERSION'] || 'latest' %>
+  product_name: chef
+  product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
+  install_strategy: once
+
+client_rb:
+  treat_deprecation_warnings_as_errors: true
 
 verifier:
   name: inspec
@@ -12,16 +17,16 @@ platforms:
   - name: amazonlinux
     driver_config:
       box: mvbcoding/awslinux
-  - name: centos-7.3
-  - name: debian-7.11
-  - name: debian-8.9
-  - name: debian-9.0
-  - name: fedora-25
-  - name: freebsd-10.3
-  - name: freebsd-11.0
-  - name: opensuse-leap-42.3
-  - name: ubuntu-14.04
+  - name: centos-7
+  - name: debian-7
+  - name: debian-8
+  - name: debian-9
+  - name: fedora-28
+  - name: freebsd-10
+  - name: freebsd-11
+  - name: opensuse-leap-42
   - name: ubuntu-16.04
+  - name: ubuntu-18.04
 
 suites:
   - name: default
@@ -75,10 +80,10 @@ suites:
       apache:
         mpm: prefork
     includes: [
-      'centos-7.3',
-      'debian-8.9',
-      'ubuntu-14.04',
-      'ubuntu-16.04'
+      'centos-7',
+      'debian-8',
+      'ubuntu-16.04',
+      'ubuntu-18.04'
       ]
 
   - name: worker
@@ -95,8 +100,8 @@ suites:
       apache:
         mpm: worker
     includes: [
-      'centos-7.3',
-      'ubuntu-14.04'
+      'centos-7',
+      'ubuntu-16.04'
       ]
 
   - name: event

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,21 @@ services: docker
 
 env:
   matrix:
-    #  - INSTANCE=default-amazonlinux # package repo times out when run in GCE with travis
-  - INSTANCE=default-centos-7
+  - INSTANCE=default-amazonlinux
   - INSTANCE=default-debian-8
   - INSTANCE=default-debian-9
+  - INSTANCE=default-centos-7
   - INSTANCE=default-fedora-latest
-  - INSTANCE=default-opensuse-leap
-  - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-ubuntu-1604
+  - INSTANCE=default-ubuntu-1804
+  - INSTANCE=default-opensuse-leap
+  - INSTANCE=prefork-debian-8
+  - INSTANCE=prefork-centos-7
+  - INSTANCE=prefork-ubuntu-1604
+  - INSTANCE=prefork-ubuntu-1804
+  - INSTANCE=worker-centos-7
+  - INSTANCE=worker-ubuntu-1604
+  - INSTANCE=event-ubuntu-1604
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 - Drop Chef 12 support
 - Add Danger and CircleCI support
 - Move apache binary detection to the helpers file
+- Update kitchen configuration
 
 ## v5.0.1 (2017-09-01)
 

--- a/test/cookbooks/apache2_test/recipes/mod_php.rb
+++ b/test/cookbooks/apache2_test/recipes/mod_php.rb
@@ -24,7 +24,7 @@ package 'which' do
   only_if { platform_family?('rhel', 'fedora', 'amazon') }
 end
 
-include_recipe 'apache2::mod_php5'
+include_recipe 'apache2::mod_php'
 
 directory node['apache_test']['app_dir'] do
   recursive true


### PR DESCRIPTION
- Platforms now use the short form.
- Provisioner now uses the curernt, product_name and product_version.

## Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
