### PR TITLE
Allow httpd -t timeout to be configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -270,3 +270,6 @@ default['apache']['default_modules'].delete('unixd') if node['platform_family'] 
 if node['init_package'] == 'systemd'
   default['apache']['default_modules'] << 'systemd' if %w(rhel amazon fedora).include?(node['platform_family'])
 end
+
+# Length in second for httpd -t to run
+default['apache']['httpd_t_timeout'] = 10

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -207,5 +207,5 @@ service 'apache2' do
   service_name platform_service_name
   supports [:start, :restart, :reload, :status]
   action [:enable, :start]
-  only_if "#{apache_binary} -t", environment: { 'APACHE_LOG_DIR' => node['apache']['log_dir'] }, timeout: 10
+  only_if "#{apache_binary} -t", environment: { 'APACHE_LOG_DIR' => node['apache']['log_dir'] }, timeout: node['apache']['httpd_t_timeout']
 end


### PR DESCRIPTION
## Description
This allow the timeout for httpd -t to be configurable.  On slower machines, this regularly times out for me, so it would be nice if I could make it a bit longer.

### Issues Resolved
None

### Check List
- [X] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [N/A] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

Not sure if this should really go in to the README?  It maybe should, but seems like an "Advanced Setting" and I don't see a section for that.  Can I get some guidance here?  Thanks!