### PR TITLE
Add Amazon Linux 2.

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -19,6 +19,11 @@ platforms:
     # Note for future cookbook contributors: faking out the network like we do above breaks the network
     # e.g. `getaddrinfo: Temporary failure in name resolution`
 
+- name: amazonlinux-2
+  driver:
+    image: dokken/amazonlinux-2
+    pid_one_command: /usr/lib/systemd/systemd
+
 - name: debian-8
   driver:
     image: dokken/debian-8

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,6 +16,9 @@ platforms:
   - name: amazonlinux
     driver_config:
       box: mvbcoding/awslinux
+  - name: amazonlinux-2
+    drive_config:
+      box: stakahashi/amazonlinux2
   - name: centos-7
   - name: debian-8
   - name: debian-9


### PR DESCRIPTION
## Description

Add Amazon Linux 2.

Notes: this currently has the same problem as Fedora 28+ where the
service won't reload

### Issues Resolved

Partly looks at supporting #565 

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
