### PR TITLE
Fix typos and documentation links in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 See UPGRADING.md for upgrading.
 
-### Behavour Changes
+### Behaviour Changes
 
 - Default recipe now calls the install resource!
 - Add helpers: for a full list see `libraries/helpers.rb`
@@ -32,7 +32,7 @@ See UPGRADING.md for upgrading.
 - Specs added for most helpers.
 - Make sysconfig paramters configurable via the install resource
 
-### Mic Updates & Improvements
+### Misc Updates & Improvements
 
 - Update README
 - Add dev-sec/apache-baseline tests and set cookbook defaults to secure defaults

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It is recommended to create a project or organization specific [wrapper cookbook
 Example wrapper cookbooks can be found in the `test/cookbooks/test` folder.
 
 # Recipes
-This cookbook comes with recipes as a way of maintaining backwards compataility.
+This cookbook comes with recipes as a way of maintaining backwards compatibility.
 It is recommended to use custom resources directly for more control.
 
 On RHEL Family distributions, certain modules ship with a config file with the package. The recipes here may delete those configuration files to ensure they don't conflict with the settings from the cookbook, which will use per-module configuration in `/etc/httpd/mods-enabled`.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The default recipe simply includes the `apache2_install` resource, using all the
 - [default_site](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_default_site.md)
 - [site](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_site.md)
 - [conf](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_conf.md)
-- [config](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2config.md)
+- [config](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_config.md)
 - [mod](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod.md)
 - [module](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_module.md)
 

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ The default recipe simply includes the `apache2_install` resource, using all the
 
 ## Resources
 
-- [install](https://github.com/sou-chefs/apache2/blob/master/documentation/resource_apache2_install.md)
-- [default_site](https://github.com/sou-chefs/apache2/blob/master/documentation/resource_apache2_default_site.md)
-- [site](https://github.com/sou-chefs/apache2/blob/master/documentation/resource_apache2_site.md)
-- [conf](https://github.com/sou-chefs/apache2/blob/master/documentation/resource_apache2_conf.md)
-- [config](https://github.com/sou-chefs/apache2/blob/master/documentation/resource_apache2config.md)
-- [mod](https://github.com/sou-chefs/apache2/blob/master/documentation/resource_apache2_mod.md)
-- [module](https://github.com/sou-chefs/apache2/blob/master/documentation/resource_apache2_module.md)
+- [install](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_install.md)
+- [default_site](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_default_site.md)
+- [site](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_site.md)
+- [conf](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_conf.md)
+- [config](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2config.md)
+- [mod](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod.md)
+- [module](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_module.md)
 
 ## License
 ```text

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -27,8 +27,8 @@ These have been removed in favour of tunable properties on each resource.
 ## What happened to apache2_web_app?
 The `apache2_web_app` resource was a wrapper around the template resource and `apache2_site` that provided little value, and restricted the the users ability to provide all the variables possible.
 
-It is recommeneded that you, manage your template and call the `apache2_site` resource directly.
+It is recommended that you manage your template and call the `apache2_site` resource directly.
 
 This leads to a simpler system, and you get more control over the variables and values you pass to the template.
 
-An example of this behaviour can be see in the `apache2_default_site` resource.
+An example of this behaviour can be seen in the `apache2_default_site` resource.

--- a/documentation/resource_apache2_site.md
+++ b/documentation/resource_apache2_site.md
@@ -2,7 +2,7 @@
 
 Enable or disable a VirtualHost in `#{apache_dir}/sites-available` by calling a2ensite or a2dissite to manage the symbolic link in `#{apache_dir}/sites-enabled`.
 
-The template for the site must be managed as a separate resource. For an example of this see `apache2_defualt_site` resource.
+The template for the site must be managed as a separate resource. For an example of this see `apache2_default_site` resource.
 
 ## Properties
 


### PR DESCRIPTION
## Description

Fixes the links to the documentation in the README and fixes some typos

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
