### PR TITLE
added default value :require property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 This file is used to list changes made in each version of the apache2 cookbook.
 
-### Unreleased
+## Unreleased
 
-- Add default value to apache_2_mod_proxy 
-
+- Add default value to apache_2_mod_proxy
 
 ## v6.0.0 (tbc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the apache2 cookbook.
 
+### Unreleased
+
+- Add default value to apache_2_mod_proxy 
+
+
 ## v6.0.0 (tbc)
 
 See UPGRADING.md for upgrading.

--- a/resources/mod_proxy.rb
+++ b/resources/mod_proxy.rb
@@ -3,7 +3,7 @@ property :proxy_requests, String,
          description: ''
 
 property :require, String,
-         default: '',
+         default: 'all denied',
          description: ''
 
 property :add_default_charset, String,


### PR DESCRIPTION
# Description
Add default value :require property for custom resource apache2_mod_proxy

## Issues Resolved

https://github.com/sous-chefs/apache2/issues/598

## Check List

- [x ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
