### PR TITLE
transparently control apache2_mod_ properties via apache2_module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the apache2 cookbook.
 
+## Unreleased
+
+- Add default value to apache_2_mod_proxy
+
 ## v6.0.0 (tbc)
 
 See UPGRADING.md for upgrading.

--- a/resources/mod_proxy.rb
+++ b/resources/mod_proxy.rb
@@ -3,7 +3,7 @@ property :proxy_requests, String,
          description: ''
 
 property :require, String,
-         default: '',
+         default: 'all denied',
          description: ''
 
 property :add_default_charset, String,

--- a/resources/module.rb
+++ b/resources/module.rb
@@ -28,7 +28,7 @@ property :apache_service_notification, Symbol,
 action :enable do
   # Call the  apache2_mod_resource if we want it configured
   if new_resource.conf
-    mod_resource_name = "apache2_mod_#{new_resource.name}"
+    mod_resource_name = "apache2_mod_#{new_resource.name}".to_sym
 
     send(mod_resource_name, 'default')
 

--- a/resources/module.rb
+++ b/resources/module.rb
@@ -34,7 +34,7 @@ action :enable do
 
     # pass Hash new_resource.mod_conf as properties
     begin
-      r = resources(mod_resource_name.to_sym => 'default')
+      r = resources(mod_resource_name: 'default')
 
       new_resource.mod_conf.each do |k, v|
         property = k.to_sym


### PR DESCRIPTION
# Description

* Add property Hash `:mod_conf`to `apache2_module`
* validate keys as existing properties
* send all key, value pairs as properties to `apache2_mod_#{new_resource.name}` 
* provide basic error handling for failing resource lookup

## Issues Resolved

https://github.com/sous-chefs/apache2/issues/600

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
