### PR TITLE
Fix spelling of default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 - Use `declare_resource` in `apache2_module`
 - Add default value to apache_2_mod_proxy
-- Fix spelling of `default` in `access_file_name` property in `install.rb` 
+- Fix spelling of `default` in `access_file_name` property in `install.rb`
 
 ## v6.0.0 (tbc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 - Use `declare_resource` in `apache2_module`
 - Add default value to apache_2_mod_proxy
+- Fix spelling of `default` in `access_file_name` property in `install.rb` 
 
 ## v6.0.0 (tbc)
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -78,7 +78,7 @@ property :run_dir, String,
 'Defaults to platform specific locations, see libraries/helpers.rb'
 
 property :access_file_name, String,
-         defualt: '.htaccess',
+         default: '.htaccess',
          description: 'Access filename'
 
 property :timeout, [Integer, String],


### PR DESCRIPTION
# Description

Fixes misspelling of `default`

## Issues Resolved

fixes: https://github.com/sous-chefs/apache2/issues/607

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
