### PR TITLE
Fixed Mutex directive commented out

### DIFF
--- a/templates/apache2.conf.erb
+++ b/templates/apache2.conf.erb
@@ -7,7 +7,7 @@ ServerRoot "<%= @apache_dir %>"
 #
 # The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
 #
-#Mutex file:<%= @lock_dir %> default
+Mutex file:<%= @lock_dir %> default
 
 #
 # The directory where shm and other runtime files will be stored.


### PR DESCRIPTION
# Description

The `Mutex` was commented out, which makes no sense since there is a default value.

## Issues Resolved

Fixes #616

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
