### PR TITLE
undefined method `apache_root_group' for Chef::Resource::Template in resource/default_site.rb

### DIFF
--- a/resources/default_site.rb
+++ b/resources/default_site.rb
@@ -70,7 +70,7 @@ action :disable do
     path "#{apache_dir}/sites-available/#{new_resource.default_site_name}.conf"
     source 'default-site.conf.erb'
     owner 'root'
-    group apache_root_group
+    group new_resource.apache_root_group
     mode '0644'
     cookbook new_resource.cookbook
     action :delete


### PR DESCRIPTION
I'm not sure why the need to use a "template" ressource to in fact delete a file, but in the current version the :disable action fail with :

  undefined method `apache_root_group' for Chef::Resource::Template

so added the necessary "new_resource." prefix