### PR TITLE
Enhance install resource to avoid configuration rewriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This file is used to list changes made in each version of the apache2 cookbook.
 - Use `declare_resource` in `apache2_module`
 - Add default value to `apache_2_mod_proxy`
 - Fix spelling of `default` in `access_file_name` property in `install.rb`
+- Allow users to set / alter the default module list
+- Allow users to alter the default modules configuration
+- Allow users to alter the mpm configuration
 
 ## v6.0.0 (25-02-2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- Allow users to set / alter the default module list
+- Allow users to alter the default modules configuration without rewrites
+- Allow users to alter the mpm configuration without rewrites
+
 ## 7.0.0 (05-03-2019)
 
 - Remove all recipes
 - Use `declare_resource` in `apache2_module`
 - Add default value to `apache_2_mod_proxy`
 - Fix spelling of `default` in `access_file_name` property in `install.rb`
-- Allow users to set / alter the default module list
-- Allow users to alter the default modules configuration
-- Allow users to alter the mpm configuration
 
 ## v6.0.0 (25-02-2019)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,3 +1,3 @@
 # Testing
 
-Please refer to [the community cookbook documentaion on testing](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD).
+Please refer to [the community cookbook documentation on testing](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD).

--- a/documentation/resource_apache2_install.md
+++ b/documentation/resource_apache2_install.md
@@ -40,7 +40,7 @@ end
 apache2_install 'default' do
   listen [ 80 ]
   mpm 'worker'
-  mpm_conf( 
+  mpm_conf(
            startservers: 10,
            serverlimit: 64,
            #maxclients    4096

--- a/documentation/resource_apache2_install.md
+++ b/documentation/resource_apache2_install.md
@@ -12,6 +12,9 @@ Installs apache2.
 | log_dir                     | String          | `default_log_dir`                   | Log directory location. Defaults to platform specific locations, see libraries/helpers.rb                      |
 | error_log                   | String          | `default_error_log`                 | Error log location. Defaults to platform specific locations, see libraries/helpers.rb                          |
 | mpm                         | String          | `default_mpm`                       | Multi-processing Module. Defaults to platform specific locations, see libraries/helpers.rb                     |
+| mpm_conf                    | Hash            | `{}`                                | Configuration parameters for the MPM.                                                                          |
+| modules                     | [String, Array] | `default_modules`                   | Defaults modules, defaults to platform specific values, see libraries/helpers.rb                               |
+| mod_conf                    | Hash            | `{}`                                | Configuration parameters for the defaults modules, as an Hash of Hash.                                         |
 | docroot_dir                 | String          | `default_docroot_dir`               | Apache document root. Defaults to platform specific locations, see libraries/helpers.rb                        |
 | run_dir                     | String          | `default_run_dir`                   | Location for APACHE_RUN_DIR. Defaults to platform specific locations, see libraries/helpers.rb                 |
 | log_level                   | String          | `warn`                              | log level for apache2                                                                                          |
@@ -30,5 +33,31 @@ Installs apache2.
 ```ruby
 apache2_install 'custom' do
   status_url 'status.site.org'
+end
+```
+
+```ruby
+apache2_install 'default' do
+  listen [ 80 ]
+  mpm 'worker'
+  mpm_conf( 
+           startservers: 10,
+           serverlimit: 64,
+           #maxclients    4096
+           minsparethreads: 64,
+           maxsparethreads: 256,
+           threadsperchild: 64,
+           #maxrequestsperchild 1024
+           maxrequestworkers: 4096,
+           maxconnectionsperchild: 1024
+          )
+  mod_conf(
+    status: {
+      status_allow_list: %w(127.0.0.1 ::1 1.2.3.0/24),
+      extended_status: 'On',
+      proxy_status: 'Off'
+    }
+  )
+  modules lazy { default_modules.delete_if { |x| x=='autoindex' } }
 end
 ```

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -51,7 +51,7 @@ property :mpm, String,
 'Defaults to platform specific locations, see libraries/helpers.rb'
 
 property :mpm_conf, Hash,
-         default: { },
+         default: {},
          description: 'Multi-processing Module configuration options.'
 
 property :modules, [String, Array],
@@ -59,7 +59,7 @@ property :modules, [String, Array],
          description: 'List of default modules activated.'
 
 property :mod_conf, Hash,
-         default: { },
+         default: {},
          description: 'other default modules optional configuration, passed with an Hash of Hash using the module name as key.'
 
 property :listen, [String, Array],


### PR DESCRIPTION
# Description

With the new (from my 3.1 perspective) ressource orientation setting the mpm configuration, removing a 'default' module or changing configuration from a default mobule induce un-necessary configuration flapping.

This PR add three properties to the install ressource to help prevent that:

 * mpm_conf: like mod_conf of module ressource, help passing parameters to the selected mpm (should be used with `mpm` property).
 * modules: allow to alter list of default modules installed.
 * mod_conf: Hash of mod_conf Hash to set defaults modules parameters.

The mod_conf property can also be used to specify mpm parameters if you would like to keep the per-platform default mpm

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
