### PR TITLE
Increase minimum chef version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ source_url       'https://github.com/sous-chefs/apache2'
 issues_url       'https://github.com/sous-chefs/apache2/issues'
 maintainer       'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
-chef_version     '>= 13.0'
+chef_version     '>= 13.9'
 license          'Apache-2.0'
 description      'Installs and configures apache2'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))


### PR DESCRIPTION
# Description

Resource property 'documentation' field has been added at 13.9 release, version should be bumped to that number at minima

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
