### PR TITLE
mod info arguments type consistency with mod-status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 - Allow users to set / alter the default module list
 - Allow users to alter the default modules configuration without rewrites
 - Allow users to alter the mpm configuration without rewrites
+- Uniform way to pass IP's in mod_info and mod_status
 
 ## 7.0.0 (05-03-2019)
 

--- a/resources/mod_info.rb
+++ b/resources/mod_info.rb
@@ -6,7 +6,7 @@ action :create do
   template ::File.join(apache_dir, 'mods-available', 'info.conf') do
     source 'mods/info.conf.erb'
     cookbook 'apache2'
-    variables(info_allow_list: new_resource.info_allow_list)
+    variables(info_allow_list: Array(new_resource.info_allow_list))
   end
 end
 

--- a/resources/mod_info.rb
+++ b/resources/mod_info.rb
@@ -1,5 +1,5 @@
-property :info_allow_list, String,
-         default: '127.0.0.1 ::1',
+property :info_allow_list, [String, Array],
+         default: %w(127.0.0.1 ::1),
          description: ''
 
 action :create do

--- a/resources/mod_status.rb
+++ b/resources/mod_status.rb
@@ -2,7 +2,7 @@ property :location, String,
          default: '/server-status',
          description: ''
 
-property :status_allow_list, Array,
+property :status_allow_list, [String, Array],
          default: %w(127.0.0.1 ::1),
          description: 'Clients in the specified IP address ranges can access the resource.
 For full description see https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html#require'
@@ -23,7 +23,7 @@ action :create do
     cookbook 'apache2'
     variables(
       location: new_resource.location,
-      status_allow_list: new_resource.status_allow_list,
+      status_allow_list: Array(new_resource.status_allow_list),
       extended_status: new_resource.extended_status,
       proxy_status: new_resource.proxy_status
     )

--- a/templates/mods/info.conf.erb
+++ b/templates/mods/info.conf.erb
@@ -2,6 +2,6 @@
   <Location /server-info>
     SetHandler server-info
     Require local
-    Require ip <%= @info_allow_list %>
+    Require ip <%= @info_allow_list.join(' ') %>
   </Location>
 </IfModule>


### PR DESCRIPTION
# Description

Allow passing the list of allowed networks for mod_info using an Array like mod-status

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
