### PR TITLE
resource/install.rb: Auto-convert the listen property to an Array when it's a type String

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,3 +34,6 @@ suites:
   - name: ssl
     run_list:
       - recipe[test::mod_ssl]
+  - name: ports
+    run_list:
+      - recipe[test::ports]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 - Allow users to set / alter the default module list
 - Allow users to alter the default modules configuration without rewrites
 - Allow users to alter the mpm configuration without rewrites
+- Fix error when passing ports as a String
 
 ## 7.0.0 (05-03-2019)
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -274,7 +274,7 @@ action :install do
     path     "#{apache_dir}/ports.conf"
     cookbook 'apache2'
     mode     '0644'
-    variables(listen: new_resource.listen)
+    variables(listen: Array(new_resource.listen))
   end
 
   # MPM Support Setup

--- a/test/cookbooks/test/recipes/ports.rb
+++ b/test/cookbooks/test/recipes/ports.rb
@@ -1,0 +1,5 @@
+apt_update 'update'
+
+apache2_install 'default_install' do
+  ports "8080"
+end

--- a/test/cookbooks/test/recipes/ports.rb
+++ b/test/cookbooks/test/recipes/ports.rb
@@ -1,5 +1,5 @@
 apt_update 'update'
 
 apache2_install 'default_install' do
-  ports "8080"
+  ports '8080'
 end

--- a/test/integration/ports/controls/default.rb
+++ b/test/integration/ports/controls/default.rb
@@ -1,0 +1,13 @@
+include_controls 'apache2-integration-tests' do
+  skip_control 'welcome-page'
+end
+
+control 'hello-world' do
+  impact 1
+  desc 'Hello World page should be visible on port 8080'
+
+  describe http('https://127.0.0.1:8080', ssl_verify: false) do
+    its('status') { should eq 200 }
+    its('body') { should cmp /Hello World/ }
+  end
+end

--- a/test/integration/ports/inspec.yml
+++ b/test/integration/ports/inspec.yml
@@ -1,0 +1,12 @@
+---
+
+name: apache2-integration-tests-port
+title: Integration tests for apache2 cookbook
+summary: This InSpec profile contains integration tests for apache2 cookbook
+supports:
+  - os-family: linux
+  - os-family: bsd
+
+depends:
+  - name: apache2-integration-tests
+    path: test/integration/default


### PR DESCRIPTION
# Description

Install resource specify the listen property as a String or an Array, however <% @listen.each do |value| -%> will fail when listen is of type String, so do a inconditionnal upgrade to an Array before handling the value to the template.

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
