### PR TITLE
standardise dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,14 +1,16 @@
 # Reference: http://danger.systems/reference.html
 
 # A pull request summary is required. Add a description of the pull request purpose.
-# Add labels to the pull request in github to identify the type of change. https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/
-# Changelog must be updated for each pull request.
+# Changelog must be updated for each pull request that changes code.
 # Warnings will be issued for:
 #    Pull request with more than 400 lines of code changed
 #    Pull reqest that change more than 5 lines without test changes
+# Failures will be issued for:
+#    Pull request without summary
+#    Pull requests with code changes without changelog entry
 
 def code_changes?
-  code = %w(libraries attributes recipes resources)
+  code = %w(libraries attributes recipes resources files templates)
   code.each do |location|
     return true unless git.modified_files.grep(/#{location}/).empty?
   end
@@ -29,7 +31,7 @@ warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
 if !git.modified_files.include?('CHANGELOG.md') && code_changes?
-  fail 'Please include a [CHANGELOG](https://github.com/sous-chefs/line-cookbook/blob/master/CHANGELOG.md) entry.'
+  fail 'Please include a CHANGELOG entry.'
 end
 
 # A sanity check for tests.


### PR DESCRIPTION
# Description

this is to create a standard dangerfile which we will use across every repository
this should have no repo specific things so we can just copy and paste it with ease, would like @damacus to sign off on this then will open against every repository

## Issues Resolved

[List any existing issues this PR resolves]

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
