### PR TITLE
Permit overwriting cookbook for apache2_mod templates

### DIFF
--- a/documentation/resource_apache2_mod.md
+++ b/documentation/resource_apache2_mod.md
@@ -10,7 +10,7 @@ This will use a template resource to write the module's configuration file in th
 | ------------ | ------ | --------------------------- | ---------------------------------------------------------------------- |
 | `template`   | String |                             | Name of the template                                                   |
 | `root_group` | String | `default_apache_root_group` | Set to override the platforms default root group for the template file |
-| `cookbook`   | String | `apache2`                   | Cookbook containing the template file
+| `template_cookbook`   | String | `apache2`                   | Cookbook containing the template file
 
 ## Examples
 

--- a/documentation/resource_apache2_mod.md
+++ b/documentation/resource_apache2_mod.md
@@ -10,6 +10,7 @@ This will use a template resource to write the module's configuration file in th
 | ------------ | ------ | --------------------------- | ---------------------------------------------------------------------- |
 | `template`   | String |                             | Name of the template                                                   |
 | `root_group` | String | `default_apache_root_group` | Set to override the platforms default root group for the template file |
+| `cookbook`   | String | `apache2`                   | Cookbook containing the template file
 
 ## Examples
 

--- a/resources/mod.rb
+++ b/resources/mod.rb
@@ -8,14 +8,14 @@ property :root_group, String,
          default: lazy { default_apache_root_group },
          description: 'Set to override the platforms default root group for the template file'
 
-property :cookbook, String,
+property :template_cookbook, String,
         default: 'apache2',
         description: 'Cookbook containing the template file'
 
 action :create do
   template ::File.join(apache_dir, 'mods-available', "#{new_resource.template}.conf") do
     source "mods/#{new_resource.template}.conf.erb"
-    cookbook new_resource.cookbook
+    cookbook new_resource.template_cookbook
     owner 'root'
     group new_resource.root_group
     mode '0644'

--- a/resources/mod.rb
+++ b/resources/mod.rb
@@ -8,10 +8,14 @@ property :root_group, String,
          default: lazy { default_apache_root_group },
          description: 'Set to override the platforms default root group for the template file'
 
+property :cookbook, String,
+        default: 'apache2',
+        description: 'Cookbook containing the template file'
+
 action :create do
   template ::File.join(apache_dir, 'mods-available', "#{new_resource.template}.conf") do
     source "mods/#{new_resource.template}.conf.erb"
-    cookbook 'apache2'
+    cookbook new_resource.cookbook
     owner 'root'
     group new_resource.root_group
     mode '0644'


### PR DESCRIPTION
# Description

Allow resource user to override which cookbook to use templates from.

## Issues Resolved

https://github.com/sous-chefs/apache2/issues/641

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
