### PR TITLE
Property mod_conf must be one of: Hash!

### DIFF
--- a/documentation/resource_apache2_install.md
+++ b/documentation/resource_apache2_install.md
@@ -51,6 +51,7 @@ apache2_install 'default' do
            maxrequestworkers: 4096,
            maxconnectionsperchild: 1024
           )
+  modules %w(status)
   mod_conf(
     status: {
       status_allow_list: %w(127.0.0.1 ::1 1.2.3.0/24),

--- a/documentation/resource_apache2_module.md
+++ b/documentation/resource_apache2_module.md
@@ -23,7 +23,7 @@ Enable the php5 module, which has a different filename than the module default:
 
 ```ruby
 apache2_module "php5" do
-  filename "libphp5.so"
+  mod_name "libphp5.so"
 end
 ```
 


### PR DESCRIPTION
Property mod_conf must be one of: Hash!  You passed nil.

# Description

```ruby
pache2_install 'default' do
  mpm 'prefork'
  mpm_conf(
      startservers: 2,
      minspareservers: 2,
      maxspareservers: 5,
      maxrequestworkers: 60,
      maxconnectionsperchild: 1000
  )
  modules %w(status)
  mod_conf(
      status: {
          status_allow_list: %w(127.0.0.1 ::1 1.2.3.0/24),
          extended_status: 'On',
          proxy_status: 'Off'
      }
  )
end
```
without modules status I get error Property mod_conf must be one of: Hash!  You passed nil.

## Issues Resolved

Wrong documentation example 

