### PR TITLE
apache2: maintain consistency with property names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This file is used to list changes made in each version of the apache2 cookbook.
 - Fixed mod_ssl for suse
 - Fixed docroot paths for suse
 
+### Breaking Changes
+
+- Renamed `:cookbook` property for `default-site` resource to `:template_cookbook`.
+
 ## 7.1.1 (2019-08-07)
 
 - Allow overwriting cookbook for apache2_mod templates using `template_cookbook` property.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ### Breaking Changes
 
-- Renamed `:cookbook` property for `default-site` resource to `:template_cookbook`.
+- Renamed `:cookbook` property for `apache2_default_site` resource to `:template_cookbook`.
 
 ## 7.1.1 (2019-08-07)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ apache2_module 'ssl'
 
 apache2_default_site 'foo' do
   default_site_name 'my_site'
-  cookbook 'my_cookbook'
+  template_cookbook 'my_cookbook'
   port '443'
   template_source 'my_site.conf.erb'
   action :enable

--- a/documentation/resource_apache2_default_site.md
+++ b/documentation/resource_apache2_default_site.md
@@ -9,7 +9,7 @@ Controls the default site.
 | default_site_name | String         | `default-site`                 | The default site name                                                                                                                    |
 | site_action       | String, Symbol | enable                         | Enable the site. Allows you to place all the configuration on disk but not enable the site                                               |
 | port              | String         | `80`                           | Listen port                                                                                                                              |
-| cookbook          | String         | `apache2`                      | Cookbook to source the template file from                                                                                                |
+| template_cookbook          | String         | `apache2`                      | Cookbook to source the template file from                                                                                                |
 | server_admin      | String         | `root@localhost`               | Default site contact name                                                                                                                |
 | log_level         | String         | `warn`                         | Log level for apache2                                                                                                                    |
 | log_dir           | String         | `default_log_dir`              | Defaults to platform specific locations, see libraries/helpers.rb                                                                        |
@@ -29,7 +29,7 @@ apache2_default_site '' do
   default_site_name String
   site_action       [String, Symbol]
   port              String
-  cookbook          String
+  template_cookbook String
   server_admin      String
   log_level         String
   action :enable

--- a/resources/default_site.rb
+++ b/resources/default_site.rb
@@ -14,7 +14,7 @@ property :port, String,
          default: '80',
          description: 'Listen port'
 
-property :cookbook, String,
+property :template_cookbook, String,
          default: 'apache2',
          description: 'Cookbook to source the template file from'
 
@@ -52,7 +52,7 @@ action :enable do
     owner 'root'
     group new_resource.apache_root_group
     mode '0644'
-    cookbook new_resource.cookbook
+    cookbook new_resource.template_cookbook
     variables(
       access_log: default_access_log,
       cgibin_dir: default_cgibin_dir,
@@ -77,7 +77,7 @@ action :disable do
     owner 'root'
     group new_resource.apache_root_group
     mode '0644'
-    cookbook new_resource.cookbook
+    cookbook new_resource.template_cookbook
     action :delete
   end
 


### PR DESCRIPTION
# Description

Rename the `cookbook` property in the `apache2_default_site` resource to `template_cookbook` to maintain consistencty.

## Issues Resolved

https://github.com/sous-chefs/apache2/issues/644

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
