### PR TITLE
Change cache_dir permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
-- Fix cache_dir permission so that modules can write in their cache_dir/<module>/ storage space
+- Fix cache_dir permission so that modules can write in their cache_dir/module/ storage space
 - Latest Cookstyle changes in cookstyle 5.6.2
 - Fixed bug with freebsd and suse modules adding an array to an array
 - Fixed mod_ssl for suse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- Fix cache_dir permission so that modules can write in their cache_dir/<module>/ storage space
 - Latest Cookstyle changes in cookstyle 5.6.2
 - Fixed bug with freebsd and suse modules adding an array to an array
 - Fixed mod_ssl for suse

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -204,7 +204,7 @@ action :install do
   end
 
   directory cache_dir do
-    mode '0750'
+    mode '0755'
     owner 'root'
     group new_resource.root_group
   end


### PR DESCRIPTION
# Description

Allow 'other' read access on the apache cache directory so that modules can write in their sub-directory

## Issues Resolved
[auth_cas:error] [..] MOD_AUTH_CAS: Could not create cache metadata file '/var/cache/apache2/mod_auth_cas/.metadata': Permission denied
 [auth_cas:error] [...] [client 172.24.56.112:56200] MOD_AUTH_CAS: Cookie file '/var/cache/apache2/mod_auth_cas/e4fad3bb784789110eab8ec240351c2f' could not be created: Permission denied

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
