### PR TITLE
Add lib_dir variable to a2enmod template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the apache2 cookbook.
 
+## Unreleased
+
+- Add missing lib_dir variable to `a2enmod` template
+
 ## 8.2.0 (2020-06-18)
 
 - Updated helpers to use platform_family? when possible to simplify code

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -144,7 +144,8 @@ action :install do
     owner 'root'
     variables(
       apachectl: apachectl,
-      apache_dir: apache_dir
+      apache_dir: apache_dir,
+      lib_dir: lib_dir
     )
     group new_resource.root_group
     action :create


### PR DESCRIPTION
# Description

The `a2enmod` template resource was not populating the `lib_dir` template variable with a value. This PR sets that variable to the correct value from the helper library.

## Issues Resolved

Fixes #651 

## Check List

- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
