### PR TITLE
Add mod_php resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - 'ssl'
           - 'ports'
           - 'module-template'
+          - 'mod-php'
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the apache2 cookbook.
 
+## Unreleased
+
+- Add `mod_php` resource
+
 ## 8.2.1 (2020-06-29)
 
 - Add missing lib_dir variable to `a2enmod` template

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Example wrapper cookbooks:
 - [config](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_config.md)
 - [mod](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod.md)
 - [module](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_module.md)
+- [mod_php](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod_php.md)
 
 ## Contributors
 

--- a/documentation/resource_apache2_mod_php.md
+++ b/documentation/resource_apache2_mod_php.md
@@ -10,7 +10,7 @@ This resource will call `_module` with the correct identifiers for you.
 
 ## Properties
 
-| Name         | Type   | Default                                     | Description                         |
-| ------------ | ------ | ------------------------------------------- | ----------------------------------- |
-| module_name  | String | `php#{node['php']['version'].to_i}_module`  | The name of the php module.         |
-| so_filename  | String | `apache_mod_php_filename`                   | The filename of the module object.  |
+| Name         | Type   | Default                      | Description                         |
+| ------------ | ------ | ---------------------------- | ----------------------------------- |
+| module_name  | String | `apache_mod_php_modulename`  | The name of the php module.         |
+| so_filename  | String | `apache_mod_php_filename`    | The filename of the module object.  |

--- a/documentation/resource_apache2_mod_php.md
+++ b/documentation/resource_apache2_mod_php.md
@@ -5,7 +5,6 @@ Enables apache2 module `mod_php`.
 This resource assumes that php has already been installed with the [`php` cookbook](https://github.com/sous-chefs/php).
 However, this resource will install the specific apache2 php module package if needed, see the `apache_mod_php_package` helper.
 
-
 **Note: call this resource directly, not through `apache2_module`!**
 This resource will call `_module` with the correct identifiers for you.
 
@@ -15,4 +14,3 @@ This resource will call `_module` with the correct identifiers for you.
 | ------------ | ------ | ------------------------------------------- | ----------------------------------- |
 | module_name  | String | `php#{node['php']['version'].to_i}_module`  | The name of the php module.         |
 | so_filename  | String | `apache_mod_php_filename`                   | The filename of the module object.  |
-

--- a/documentation/resource_apache2_mod_php.md
+++ b/documentation/resource_apache2_mod_php.md
@@ -3,6 +3,8 @@
 Enables apache2 module `mod_php`.
 
 This resource assumes that php has already been installed with the [`php` cookbook](https://github.com/sous-chefs/php).
+However, this resource will install the specific apache2 php module package if needed, see the `apache_mod_php_package` helper.
+
 
 **Note: call this resource directly, not through `apache2_module`!**
 This resource will call `_module` with the correct identifiers for you.
@@ -12,5 +14,5 @@ This resource will call `_module` with the correct identifiers for you.
 | Name         | Type   | Default                                     | Description                         |
 | ------------ | ------ | ------------------------------------------- | ----------------------------------- |
 | module_name  | String | `php#{node['php']['version'].to_i}_module`  | The name of the php module.         |
-| so_filename  | String | `libphp#{node['php']['version'].to_i}.so`   | The filename of the module object.  |
+| so_filename  | String | `apache_mod_php_filename`                   | The filename of the module object.  |
 

--- a/documentation/resource_apache2_mod_php.md
+++ b/documentation/resource_apache2_mod_php.md
@@ -2,8 +2,8 @@
 
 Enables apache2 module `mod_php`.
 
-This resource assumes that php has already been installed with the [`php` cookbook](https://github.com/sous-chefs/php).
-However, this resource will install the specific apache2 php module package if needed, see the `apache_mod_php_package` helper.
+This resource will install and enable the Apache PHP module. See `apache_mod_php_package` for the platform-specific module package.
+If installing PHP outside of this resource (i.e. with the [`php` cookbook](https://github.com/sous-chefs/php)), you should set `install_package` to false to avoid a possible version conflict.
 
 **Note: call this resource directly, not through `apache2_module`!**
 This resource will call `_module` with the correct identifiers for you.
@@ -15,4 +15,4 @@ This resource will call `_module` with the correct identifiers for you.
 | module_name      | String | `apache_mod_php_modulename`  | The name of the php module.                                                                                     |
 | so_filename      | String | `apache_mod_php_filename`    | The filename of the module object.                                                                              |
 | package_name     | String | `apache_mod_php_package`     | The package that contains the PHP module itself, which is sometimes not included with the default PHP packages. |
-| install_package  | Bool   | `false`                      | Whether to install the PHP module package.                                                                      |
+| install_package  | Bool   | `true`                       | Whether to install the PHP module package.                                                                      |

--- a/documentation/resource_apache2_mod_php.md
+++ b/documentation/resource_apache2_mod_php.md
@@ -10,7 +10,9 @@ This resource will call `_module` with the correct identifiers for you.
 
 ## Properties
 
-| Name         | Type   | Default                      | Description                         |
-| ------------ | ------ | ---------------------------- | ----------------------------------- |
-| module_name  | String | `apache_mod_php_modulename`  | The name of the php module.         |
-| so_filename  | String | `apache_mod_php_filename`    | The filename of the module object.  |
+| Name             | Type   | Default                      | Description                                                                                                     |
+| ---------------- | ------ | ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| module_name      | String | `apache_mod_php_modulename`  | The name of the php module.                                                                                     |
+| so_filename      | String | `apache_mod_php_filename`    | The filename of the module object.                                                                              |
+| package_name     | String | `apache_mod_php_package`     | The package that contains the PHP module itself, which is sometimes not included with the default PHP packages. |
+| install_package  | Bool   | `false`                      | Whether to install the PHP module package.                                                                      |

--- a/documentation/resource_apache2_mod_php.md
+++ b/documentation/resource_apache2_mod_php.md
@@ -1,0 +1,16 @@
+# apache2_mod_php
+
+Enables apache2 module `mod_php`.
+
+This resource assumes that php has already been installed with the [`php` cookbook](https://github.com/sous-chefs/php).
+
+**Note: call this resource directly, not through `apache2_module`!**
+This resource will call `_module` with the correct identifiers for you.
+
+## Properties
+
+| Name         | Type   | Default                                     | Description                         |
+| ------------ | ------ | ------------------------------------------- | ----------------------------------- |
+| module_name  | String | `php#{node['php']['version'].to_i}_module`  | The name of the php module.         |
+| so_filename  | String | `libphp#{node['php']['version'].to_i}.so`   | The filename of the module object.  |
+

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -13,6 +13,11 @@ provisioner:
   name: dokken
 
 platforms:
+  - name: amazonlinux-2
+    driver:
+      mage: dokken/amazonlinux-2
+      pid_one_command: /usr/lib/systemd/systemd
+                  
   - name: debian-9
     driver:
       image: dokken/debian-9

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -17,7 +17,7 @@ platforms:
     driver:
       mage: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
-                  
+
   - name: debian-9
     driver:
       image: dokken/debian-9

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,7 +4,6 @@ driver:
 
 provisioner:
   name: chef_solo
-  product_name: chef
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
@@ -39,3 +38,6 @@ suites:
   - name: module_template
     run_list:
       - recipe[test::module_template]
+  - name: mod_php
+    run_list:
+      - recipe[test::php]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_solo
-#  product_name: chef
+  product_name: chef
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,6 +4,7 @@ driver:
 
 provisioner:
   name: chef_solo
+  product_name: chef
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -360,7 +360,6 @@ module Apache2
               mime
               negotiation
               pagespeed
-              php
               proxy_balancer
               proxy_ftp
               proxy

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,3 +1,4 @@
+
 module Apache2
   module Cookbook
     module Helpers
@@ -392,20 +393,25 @@ module Apache2
         platform_family?('debian') ? "#{default_site_name}.conf.erb" : 'welcome.conf.erb'
       end
 
-      def apache_default_php_version
+      def apache_mod_php_package
         case node['platform_family']
         when 'debian'
-          if platform?('ubuntu') && node['platform_version'].to_f >= 16.04
-            '7'
-          elsif platform?('debian') && node['platform_version'].to_f >= 9
-            '7'
-          else
-            '5'
-          end
+          "libapache2-mod-php#{node['php']['version'].to_f}"
+        when 'rhel', 'fedora'
+          'mod_php'
+        when 'suse'
+          "apache2-mod_php#{node['php']['version'].to_i}"
+        end
+      end
+
+      def apache_mod_php_filename
+        case node['platform_family']
         when 'rhel'
-          node['platform_version'] >= 8 ? '7' : '5'
+          "libphp#{node['php']['version'].to_i}.so"
+        when 'debian'
+          "libphp#{node['php']['version'].to_f}.so"
         else
-          '5'
+          "libphp#{node['php']['version'].to_i}.so"
         end
       end
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -396,19 +396,32 @@ module Apache2
       def apache_mod_php_package
         case node['platform_family']
         when 'debian'
-          "libapache2-mod-php#{node['php']['version'].to_f}"
+          'libapache2-mod-php'
         when 'rhel', 'fedora'
           'mod_php'
         when 'suse'
-          "apache2-mod_php#{node['php']['version'].to_i}"
+          'apache2-mod_php7'
         end
       end
 
       def apache_mod_php_filename
-        if platform_family?('debian')
-          "libphp#{node['php']['version'].to_f}.so" # libphp7.2.so
+        case platform_family?
+        when 'debian'
+          if platform?('debian') && node['platform_version'].to_i >= 10
+            'libphp7.3.so'
+          elsif platform?('ubuntu') && node['platform_version'].to_f == 18.04
+            'libphp7.2.so'
+          elsif platform?('ubuntu') && node['platform_version'].to_f >= 20.04
+            'libphp7.4.so'
+          else
+            'libphp7.0.so'
+          end
         else
-          "libphp#{node['php']['version'].to_i}.so" # libphp7.so
+          if (platform_family?('rhel') && node['platform_version'].to_i == 7) || platform?('amazon')
+            'libphp5.so'
+          else
+            'libphp7.so'
+          end
         end
       end
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -397,7 +397,7 @@ module Apache2
         case node['platform_family']
         when 'debian'
           'libapache2-mod-php'
-        when 'rhel', 'fedora'
+        when 'rhel', 'fedora', 'amazon'
           'mod_php'
         when 'suse'
           'apache2-mod_php7'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -404,6 +404,21 @@ module Apache2
         end
       end
 
+      def apache_mod_php_modulename
+        case node['platform_family']
+        when 'amazon'
+          'php5_module'
+        when 'rhel'
+          if node['platform_version'].to_i >= 8
+            'php7_module'
+          else
+            'php5_module'
+          end
+        else
+          'php7_module'
+        end
+      end
+
       def apache_mod_php_filename
         case node['platform_family']
         when 'debian'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -405,13 +405,10 @@ module Apache2
       end
 
       def apache_mod_php_filename
-        case node['platform_family']
-        when 'rhel'
-          "libphp#{node['php']['version'].to_i}.so"
-        when 'debian'
-          "libphp#{node['php']['version'].to_f}.so"
+        if platform_family?('debian')
+          "libphp#{node['php']['version'].to_f}.so" # libphp7.2.so
         else
-          "libphp#{node['php']['version'].to_i}.so"
+          "libphp#{node['php']['version'].to_i}.so" # libphp7.so
         end
       end
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -360,6 +360,7 @@ module Apache2
               mime
               negotiation
               pagespeed
+              php
               proxy_balancer
               proxy_ftp
               proxy
@@ -390,6 +391,23 @@ module Apache2
 
       def default_site_template_source
         platform_family?('debian') ? "#{default_site_name}.conf.erb" : 'welcome.conf.erb'
+      end
+
+      def apache_default_php_version
+        case node['platform_family']
+        when 'debian'
+          if platform?('ubuntu') && node['platform_version'].to_f >= 16.04
+            '7'
+          elsif platform?('debian') && node['platform_version'].to_f >= 9
+            '7'
+          else
+            '5'
+          end
+        when 'rhel'
+          node['platform_version'] >= 8 ? '7' : '5'
+        else
+          '5'
+        end
       end
     end
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -439,8 +439,8 @@ module Apache2
           end
         when 'amazon'
           'libphp5.so'
-        else
-          'libphp7.so'
+        when 'suse'
+          'mod_php7.so'
         end
       end
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -405,7 +405,7 @@ module Apache2
       end
 
       def apache_mod_php_filename
-        case platform_family?
+        case node['platform_family']
         when 'debian'
           if platform?('debian') && node['platform_version'].to_i >= 10
             'libphp7.3.so'
@@ -416,12 +416,16 @@ module Apache2
           else
             'libphp7.0.so'
           end
-        else
-          if (platform_family?('rhel') && node['platform_version'].to_i == 7) || platform?('amazon')
-            'libphp5.so'
-          else
+        when 'rhel'
+          if node['platform_version'].to_i >= 8
             'libphp7.so'
+          else
+            'libphp5.so'
           end
+        when 'amazon'
+          'libphp5.so'
+        else
+          'libphp7.so'
         end
       end
     end

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -2,45 +2,34 @@ include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :module_name, String,
-         default: lazy { "php#{apache_default_php_version}" },
+         default: lazy { "php#{node['php']['version'].to_i}_module" },
          description: 'Module name for the Apache PHP module.'
 
 property :so_filename, String,
-         default: lazy { "libphp#{apache_default_php_version}.so" },
+         default: lazy { "libphp#{node['php']['version'].to_i}.so" },
          description: 'Filename for the module executable.'
 
 action :create do
-  case node['platform_family']
-  when 'debian'
-    if platform?('ubuntu') && node['platform_version'].to_f < 16.04
-      package 'libapache2-mod-php5'
-    elsif platform?('debian') && node['platform_version'].to_f < 9
-      package 'libapache2-mod-php5'
-    else
-      package 'libapache2-mod-php'
-    end
-  when 'arch'
-    package 'php-apache' do
-      notifies :run, 'execute[generate-module-list]', :immediately
-    end
-  when 'rhel', 'amazon', 'fedora', 'suse'
-    package 'which'
-    package 'php' do
-      notifies :run, 'execute[generate-module-list]', :immediately
-      not_if 'which php'
-    end
-  when 'freebsd'
-    package %w(php56 libxml2)
-
-    %w(mod_php56).each do |pkg|
-      package pkg do
-        options '-I'
-      end
-    end
-  end
-
-  template ::File.join(apache_dir, 'mods-available', 'php.conf') do
+  template ::File.join(apache_dir, 'mods-available', "php.conf") do
     source 'mods/php.conf.erb'
     cookbook 'apache2'
+    notifies :reload, 'service[apache2]', :delayed
+  end
+
+  link ::File.join(apache_dir, 'mods-enabled', "php.conf") do
+    to ::File.join(apache_dir, 'mods-available', "php.conf")
+    notifies :reload, 'service[apache2]', :delayed
+  end
+
+  directory '/var/lib/php/session' do
+    owner 'root'
+    group 'apache'
+    mode '0770'
+  end
+
+  apache2_module "php#{node['php']['version'].to_i}" do
+    identifier new_resource.module_name
+    mod_name new_resource.so_filename
+    notifies :reload, 'service[apache2]', :immediately
   end
 end

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -18,7 +18,7 @@ property :install_package, [true, false],
          description: 'Whether to install the Apache PHP module package'
 
 action :create do
-  # install mod_php package
+  # install mod_php package (if requested)
   package new_resource.package_name if new_resource.install_package
 
   # manually manage conf file since filename is different than module
@@ -26,12 +26,6 @@ action :create do
     source 'mods/php.conf.erb'
     cookbook 'apache2'
     notifies :reload, 'service[apache2]', :delayed
-  end
-
-  directory '/var/lib/php/session' do
-    owner 'root'
-    group default_apache_group
-    mode '770'
   end
 
   apache2_module 'php' do

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -2,7 +2,7 @@ include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :module_name, String,
-         default: lazy { "php#{node['php']['version'].to_i}_module" },
+         default: lazy { apache_mod_php_modulename },
          description: 'Module name for the Apache PHP module.'
 
 property :so_filename, String,
@@ -31,7 +31,7 @@ action :create do
     mode '770'
   end
 
-  apache2_module "php#{node['php']['version'].to_i}" do
+  apache2_module 'php' do
     identifier new_resource.module_name
     mod_name new_resource.so_filename
     notifies :reload, 'service[apache2]', :immediately

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -23,7 +23,7 @@ action :create do
 
   directory '/var/lib/php/session' do
     owner 'root'
-    group 'apache'
+    group default_apache_group
     mode '0770'
   end
 

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -9,9 +9,17 @@ property :so_filename, String,
          default: lazy { apache_mod_php_filename },
          description: 'Filename for the module executable.'
 
+property :package_name, String,
+         default: lazy { apache_mod_php_package },
+         description: 'Package that contains the Apache PHP module itself'
+
+property :install_package, [true, false],
+         default: true,
+         description: 'Whether to install the Apache PHP module package'
+
 action :create do
   # install mod_php package
-  package apache_mod_php_package unless apache_mod_php_package.nil?
+  package new_resource.package_name if new_resource.install_package
 
   # manually manage conf file since filename is different than module
   template ::File.join(apache_dir, 'mods-available', 'php.conf') do

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -10,14 +10,14 @@ property :so_filename, String,
          description: 'Filename for the module executable.'
 
 action :create do
-  template ::File.join(apache_dir, 'mods-available', "php.conf") do
+  template ::File.join(apache_dir, 'mods-available', 'php.conf') do
     source 'mods/php.conf.erb'
     cookbook 'apache2'
     notifies :reload, 'service[apache2]', :delayed
   end
 
-  link ::File.join(apache_dir, 'mods-enabled', "php.conf") do
-    to ::File.join(apache_dir, 'mods-available', "php.conf")
+  link ::File.join(apache_dir, 'mods-enabled', 'php.conf') do
+    to ::File.join(apache_dir, 'mods-available', 'php.conf')
     notifies :reload, 'service[apache2]', :delayed
   end
 

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -28,11 +28,6 @@ action :create do
     notifies :reload, 'service[apache2]', :delayed
   end
 
-  link ::File.join(apache_dir, 'mods-enabled', 'php.conf') do
-    to ::File.join(apache_dir, 'mods-available', 'php.conf')
-    notifies :reload, 'service[apache2]', :delayed
-  end
-
   directory '/var/lib/php/session' do
     owner 'root'
     group default_apache_group

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -1,0 +1,46 @@
+include Apache2::Cookbook::Helpers
+unified_mode true
+
+property :module_name, String,
+         default: lazy { "php#{apache_default_php_version}" },
+         description: 'Module name for the Apache PHP module.'
+
+property :so_filename, String,
+         default: lazy { "libphp#{apache_default_php_version}.so" },
+         description: 'Filename for the module executable.'
+
+action :create do
+  case node['platform_family']
+  when 'debian'
+    if platform?('ubuntu') && node['platform_version'].to_f < 16.04
+      package 'libapache2-mod-php5'
+    elsif platform?('debian') && node['platform_version'].to_f < 9
+      package 'libapache2-mod-php5'
+    else
+      package 'libapache2-mod-php'
+    end
+  when 'arch'
+    package 'php-apache' do
+      notifies :run, 'execute[generate-module-list]', :immediately
+    end
+  when 'rhel', 'amazon', 'fedora', 'suse'
+    package 'which'
+    package 'php' do
+      notifies :run, 'execute[generate-module-list]', :immediately
+      not_if 'which php'
+    end
+  when 'freebsd'
+    package %w(php56 libxml2)
+
+    %w(mod_php56).each do |pkg|
+      package pkg do
+        options '-I'
+      end
+    end
+  end
+
+  template ::File.join(apache_dir, 'mods-available', 'php.conf') do
+    source 'mods/php.conf.erb'
+    cookbook 'apache2'
+  end
+end

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -1,5 +1,4 @@
 include Apache2::Cookbook::Helpers
-unified_mode true
 
 property :name, String, default: ''
 

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -6,10 +6,13 @@ property :module_name, String,
          description: 'Module name for the Apache PHP module.'
 
 property :so_filename, String,
-         default: lazy { "libphp#{node['php']['version'].to_i}.so" },
+         default: lazy { apache_mod_php_filename },
          description: 'Filename for the module executable.'
 
 action :create do
+  # install mod_php package
+  package apache_mod_php_package unless apache_mod_php_package.nil?
+
   # manually manage conf file since filename is different than module
   template ::File.join(apache_dir, 'mods-available', 'php.conf') do
     source 'mods/php.conf.erb'

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -10,6 +10,7 @@ property :so_filename, String,
          description: 'Filename for the module executable.'
 
 action :create do
+  # manually manage conf file since filename is different than module
   template ::File.join(apache_dir, 'mods-available', 'php.conf') do
     source 'mods/php.conf.erb'
     cookbook 'apache2'
@@ -24,7 +25,7 @@ action :create do
   directory '/var/lib/php/session' do
     owner 'root'
     group default_apache_group
-    mode '0770'
+    mode '770'
   end
 
   apache2_module "php#{node['php']['version'].to_i}" do

--- a/spec/resources/mod_php_spec.rb
+++ b/spec/resources/mod_php_spec.rb
@@ -37,7 +37,7 @@ describe 'apache2_mod_php' do
     it do
       is_expected.to enable_apache2_module('php7').with(
         identifier: 'php7_module',
-        mod_name: 'libphp7.so'
+        mod_name: 'libphp7.0.so'
       )
     end
   end

--- a/spec/resources/mod_php_spec.rb
+++ b/spec/resources/mod_php_spec.rb
@@ -5,7 +5,7 @@ describe 'apache2_mod_php' do
 
   platform 'ubuntu'
 
-  context 'Setup and enable php module' do
+  context 'Setup and enable PHP module' do
     recipe do
       apache2_install 'phptest'
       apache2_mod_php 'phptest'
@@ -13,6 +13,10 @@ describe 'apache2_mod_php' do
 
     before do
       stub_command('/usr/sbin/apache2ctl -t').and_return('foo')
+    end
+
+    it do
+      is_expected.to install_package('libapache2-mod-php')
     end
 
     it do
@@ -38,6 +42,50 @@ describe 'apache2_mod_php' do
         identifier: 'php7_module',
         mod_name: 'libphp7.4.so'
       )
+    end
+  end
+
+  context 'Enable PHP module with custom properties' do
+    recipe do
+      apache2_install 'phpcustom'
+      apache2_mod_php 'phpcustom' do
+        module_name 'phptest_module'
+        so_filename 'libphptest.so'
+        package_name 'mod_phptest'
+      end
+    end
+
+    before do
+      stub_command('/usr/sbin/apache2ctl -t').and_return('foo')
+    end
+
+    it do
+      is_expected.to install_package('mod_phptest')
+    end
+
+    it do
+      is_expected.to enable_apache2_module('php').with(
+        identifier: 'phptest_module',
+        mod_name: 'libphptest.so'
+      )
+    end
+  end
+
+  context 'Do not install module package' do
+    recipe do
+      apache2_install 'phpcustom'
+      apache2_mod_php 'phpcustom' do
+        package_name 'mod_phptest'
+        install_package false
+      end
+    end
+
+    before do
+      stub_command('/usr/sbin/apache2ctl -t').and_return('foo')
+    end
+
+    it do
+      is_expected.to_not install_package('mod_phptest')
     end
   end
 end

--- a/spec/resources/mod_php_spec.rb
+++ b/spec/resources/mod_php_spec.rb
@@ -24,14 +24,6 @@ describe 'apache2_mod_php' do
     end
 
     it do
-      is_expected.to create_directory('/var/lib/php/session').with(
-        owner: 'root',
-        group: 'www-data',
-        mode: '770'
-      )
-    end
-
-    it do
       is_expected.to enable_apache2_module('php').with(
         identifier: 'php7_module',
         mod_name: 'libphp7.4.so'

--- a/spec/resources/mod_php_spec.rb
+++ b/spec/resources/mod_php_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe 'apache2_mod_php' do
   step_into :apache2_install, :apache2_mod_php, :apache2_module
+  default_attributes['php']['version'] = '7.2.31'
+
   platform 'ubuntu'
 
   context 'Setup and enable php module' do
-    default_attributes['php']['version'] = '7.0.4'
-
     recipe do
       apache2_install 'phptest'
       apache2_mod_php 'phptest'
@@ -37,7 +37,7 @@ describe 'apache2_mod_php' do
     it do
       is_expected.to enable_apache2_module('php7').with(
         identifier: 'php7_module',
-        mod_name: 'libphp7.0.so'
+        mod_name: 'libphp7.so'
       )
     end
   end

--- a/spec/resources/mod_php_spec.rb
+++ b/spec/resources/mod_php_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'apache2_mod_php' do
+  step_into :apache2_install, :apache2_mod_php, :apache2_module
+  platform 'ubuntu'
+
+  context 'Setup and enable php module' do
+    default_attributes['php']['version'] = '7.0.4'
+
+    recipe do
+      apache2_install 'phptest'
+      apache2_mod_php 'phptest'
+    end
+
+    before do
+      stub_command('/usr/sbin/apache2ctl -t').and_return('foo')
+    end
+
+    it do
+      is_expected.to create_template('/etc/apache2/mods-available/php.conf')
+    end
+
+    it do
+      is_expected.to create_link('/etc/apache2/mods-enabled/php.conf').with(
+        to: '/etc/apache2/mods-available/php.conf'
+      )
+    end
+
+    it do
+      is_expected.to create_directory('/var/lib/php/session').with(
+        owner: 'root',
+        group: 'www-data',
+        mode: '770'
+      )
+    end
+
+    it do
+      is_expected.to enable_apache2_module('php7').with(
+        identifier: 'php7_module',
+        mod_name: 'libphp7.so'
+      )
+    end
+  end
+end

--- a/spec/resources/mod_php_spec.rb
+++ b/spec/resources/mod_php_spec.rb
@@ -24,12 +24,6 @@ describe 'apache2_mod_php' do
     end
 
     it do
-      is_expected.to create_link('/etc/apache2/mods-enabled/php.conf').with(
-        to: '/etc/apache2/mods-available/php.conf'
-      )
-    end
-
-    it do
       is_expected.to create_directory('/var/lib/php/session').with(
         owner: 'root',
         group: 'www-data',

--- a/spec/resources/mod_php_spec.rb
+++ b/spec/resources/mod_php_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe 'apache2_mod_php' do
   step_into :apache2_install, :apache2_mod_php, :apache2_module
-  default_attributes['php']['version'] = '7.2.31'
 
   platform 'ubuntu'
 
@@ -35,9 +34,9 @@ describe 'apache2_mod_php' do
     end
 
     it do
-      is_expected.to enable_apache2_module('php7').with(
+      is_expected.to enable_apache2_module('php').with(
         identifier: 'php7_module',
-        mod_name: 'libphp7.so'
+        mod_name: 'libphp7.4.so'
       )
     end
   end

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -8,4 +8,3 @@ version           '0.0.1'
 
 depends           'apache2'
 depends           'apt'
-depends           'php'

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -5,5 +5,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Testing cookbook for apache2'
 version           '0.0.1'
+
 depends           'apache2'
 depends           'apt'
+depends           'php'

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -6,7 +6,9 @@ end
 
 include_recipe 'php'
 
-apache2_install 'default'
+apache2_install 'default' do
+  mpm 'prefork'
+end
 
 service 'apache2' do
   extend Apache2::Cookbook::Helpers
@@ -22,3 +24,5 @@ file "#{default_docroot_dir}/info.php" do
 end
 
 apache2_default_site 'php_test'
+
+package 'curl' if platform?('debian')

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -1,7 +1,7 @@
 ::Chef::Recipe.include Apache2::Cookbook::Helpers
 
-if (node['platform_family'] == 'rhel') && (node['platform_version'].to_i >= 8)
-    node.default['php']['version'] = '7.0.4'
+if platform_family?('rhel') && (node['platform_version'].to_i >= 8)
+  node.default['php']['version'] = '7.0.4'
 end
 
 include_recipe 'php'

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -1,6 +1,18 @@
 ::Chef::Recipe.include Apache2::Cookbook::Helpers
 
-include_recipe 'php'
+directory 'purge distro conf.modules.d' do
+  extend Apache2::Cookbook::Helpers
+  path "#{apache_dir}/conf.modules.d"
+  recursive true
+  action :nothing # trigger this in other resources as needed
+end
+
+directory 'purge distro conf.d' do
+  extend Apache2::Cookbook::Helpers
+  path "#{apache_dir}/conf.d"
+  recursive true
+  action :nothing # trigger this in other resources as needed
+end
 
 apache2_install 'default' do
   mpm 'prefork'
@@ -13,7 +25,10 @@ service 'apache2' do
   action [:start, :enable]
 end
 
-apache2_mod_php ''
+apache2_mod_php '' do
+  notifies :delete, 'directory[purge distro conf.modules.d]'
+  notifies :delete, 'directory[purge distro conf.d]'
+end
 
 file "#{default_docroot_dir}/info.php" do
   content "<?php\nphpinfo();\n?>"

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -1,7 +1,5 @@
 ::Chef::Recipe.include Apache2::Cookbook::Helpers
 
-
-
 directory 'purge distro conf.modules.d' do
   extend Apache2::Cookbook::Helpers
   path "#{apache_dir}/conf.modules.d"

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -1,5 +1,7 @@
 ::Chef::Recipe.include Apache2::Cookbook::Helpers
 
+
+
 directory 'purge distro conf.modules.d' do
   extend Apache2::Cookbook::Helpers
   path "#{apache_dir}/conf.modules.d"

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -1,19 +1,5 @@
 ::Chef::Recipe.include Apache2::Cookbook::Helpers
 
-directory 'purge distro conf.modules.d' do
-  extend Apache2::Cookbook::Helpers
-  path "#{apache_dir}/conf.modules.d"
-  recursive true
-  action :nothing # trigger this in other resources as needed
-end
-
-directory 'purge distro conf.d' do
-  extend Apache2::Cookbook::Helpers
-  path "#{apache_dir}/conf.d"
-  recursive true
-  action :nothing # trigger this in other resources as needed
-end
-
 apache2_install 'default' do
   mpm 'prefork'
 end
@@ -25,10 +11,7 @@ service 'apache2' do
   action [:start, :enable]
 end
 
-apache2_mod_php '' do
-  notifies :delete, 'directory[purge distro conf.modules.d]'
-  notifies :delete, 'directory[purge distro conf.d]'
-end
+apache2_mod_php
 
 file "#{default_docroot_dir}/info.php" do
   content "<?php\nphpinfo();\n?>"

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -1,0 +1,24 @@
+::Chef::Recipe.include Apache2::Cookbook::Helpers
+
+if (node['platform_family'] == 'rhel') && (node['platform_version'].to_i >= 8)
+    node.default['php']['version'] = '7.0.4'
+end
+
+include_recipe 'php'
+
+apache2_install 'default'
+
+service 'apache2' do
+  extend Apache2::Cookbook::Helpers
+  service_name lazy { apache_platform_service_name }
+  supports restart: true, status: true, reload: true
+  action [:start, :enable]
+end
+
+apache2_mod_php ''
+
+file "#{default_docroot_dir}/info.php" do
+  content "<?php\nphpinfo();\n?>"
+end
+
+apache2_default_site 'php_test'

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -1,9 +1,5 @@
 ::Chef::Recipe.include Apache2::Cookbook::Helpers
 
-if platform_family?('rhel') && (node['platform_version'].to_i >= 8)
-  node.default['php']['version'] = '7.0.4'
-end
-
 include_recipe 'php'
 
 apache2_install 'default' do

--- a/test/integration/basic_site/controls/default.rb
+++ b/test/integration/basic_site/controls/default.rb
@@ -4,7 +4,7 @@ end
 
 control 'hello-world' do
   impact 1
-  desc 'Hello World page sgould be visible'
+  desc 'Hello World page should be visible'
 
   describe http('localhost') do
     its('status') { should eq 200 }

--- a/test/integration/mod_php/controls/default.rb
+++ b/test/integration/mod_php/controls/default.rb
@@ -1,0 +1,35 @@
+include_controls 'apache2-integration-tests' do
+  skip_control 'welcome-page'
+end
+
+control 'PHP module enabled & running' do
+  impact 1
+  desc 'php module should be enabled with config'
+
+  describe command('apachectl -M | grep php') do
+    its('stdout') { should match(/php/) }
+  end
+
+  case os['family']
+  when 'debian', 'suse'
+    describe file('/etc/apache2/mods-available/php.conf') do
+      it { should exist }
+      its('content') { should match %r{SetHandler application/x-httpd-php} }
+    end
+  when 'freebsd'
+    describe file('/usr/local/etc/apache24/mods-available/php.conf') do
+      it { should exist }
+      its('content') { should match %r{SetHandler application/x-httpd-php} }
+    end
+  else
+    describe file('/etc/httpd/mods-available/php.conf') do
+      it { should exist }
+      its('content') { should match %r{SetHandler application/x-httpd-php} }
+    end
+  end
+
+  describe http('localhost/info.php', enable_remote_worker: true) do
+    its('status') { should eq 200 }
+    its('body') { should match /PHP Version/ }
+  end
+end

--- a/test/integration/mod_php/controls/default.rb
+++ b/test/integration/mod_php/controls/default.rb
@@ -6,7 +6,7 @@ control 'PHP module enabled & running' do
   impact 1
   desc 'php module should be enabled with config'
 
-  describe command('apachectl -M | grep php') do
+  describe command('apachectl -M') do
     its('stdout') { should match(/php/) }
   end
 

--- a/test/integration/mod_php/inspec.yml
+++ b/test/integration/mod_php/inspec.yml
@@ -1,0 +1,11 @@
+---
+name: apache2-integration-tests
+title: Integration tests for apache2 cookbook
+summary: This InSpec profile contains integration tests for apache2 cookbook
+supports:
+  - os-family: linux
+  - os-family: bsd
+
+depends:
+  - name: apache2-integration-tests
+    path: test/integration/default


### PR DESCRIPTION
# Description

This PR adds a new `apache2_mod_php` resource to configure and enable PHP.

## Issues Resolved

Fixes #576.

## Check List

- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
