### PR TITLE
Directly include Apache2::Cookbook::Helpers in recipes and resources by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 - resolved cookstyle error: spec/libraries/default_modules_spec.rb:8:7 refactor: `ChefCorrectness/IncorrectLibraryInjection`
 - Cookstyle Bot Auto Corrections with Cookstyle 6.17.7
+- Directly include Apache2::Cookbook::Helpers in recipes and resources by default
 
 ## 8.4.0 (2020-09-09)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ It is recommended to create a project or organization specific [wrapper cookbook
 ```ruby
 # service['apache2'] is defined in the apache2_default_install resource but other resources are currently unable to reference it.  To work around this issue, define the following helper in your cookbook:
 service 'apache2' do
-  extend Apache2::Cookbook::Helpers
   service_name lazy { apache_platform_service_name }
   supports restart: true, status: true, reload: true
   action :nothing

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -97,7 +97,6 @@ To work around this issue, define the following helper in your cookbook:
 
 ```ruby
 service 'apache2' do
-  extend Apache2::Cookbook::Helpers
   service_name lazy { apache_platform_service_name }
   supports restart: true, status: true, reload: true
   action :nothing

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,4 +1,3 @@
-
 module Apache2
   module Cookbook
     module Helpers
@@ -446,3 +445,6 @@ module Apache2
     end
   end
 end
+
+Chef::DSL::Recipe.include Apache2::Cookbook::Helpers
+Chef::Resource.include Apache2::Cookbook::Helpers

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :path, String,

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :root_group, String,

--- a/resources/default_site.rb
+++ b/resources/default_site.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :default_site_name, String,

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :apache_pkg, String,

--- a/resources/mod.rb
+++ b/resources/mod.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :template, String,

--- a/resources/mod_alias.rb
+++ b/resources/mod_alias.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :options, Array,

--- a/resources/mod_auth_cas.rb
+++ b/resources/mod_auth_cas.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :install_method, String,

--- a/resources/mod_autoindex.rb
+++ b/resources/mod_autoindex.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :index_options, Array,

--- a/resources/mod_cache_disk.rb
+++ b/resources/mod_cache_disk.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :cache_root, String,

--- a/resources/mod_cgid.rb
+++ b/resources/mod_cgid.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :script_sock, String,

--- a/resources/mod_dav_fs.rb
+++ b/resources/mod_dav_fs.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :dav_lock_db, String,

--- a/resources/mod_fastcgi.rb
+++ b/resources/mod_fastcgi.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :fast_cgi_wrapper, String,

--- a/resources/mod_mime.rb
+++ b/resources/mod_mime.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :types_config, String,

--- a/resources/mod_mime_magic.rb
+++ b/resources/mod_mime_magic.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :mime_magic_file, String,

--- a/resources/mod_pagespeed.rb
+++ b/resources/mod_pagespeed.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :apache_user, String,

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -1,5 +1,3 @@
-include Apache2::Cookbook::Helpers
-
 property :name, String, default: ''
 
 property :module_name, String,

--- a/resources/mod_ssl.rb
+++ b/resources/mod_ssl.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :mod_ssl_pkg, String,

--- a/resources/mod_userdir.rb
+++ b/resources/mod_userdir.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :public_html_dir, String,

--- a/resources/module.rb
+++ b/resources/module.rb
@@ -1,4 +1,3 @@
-include Apache2::Cookbook::Helpers
 unified_mode true
 
 property :mod_name, String,

--- a/test/cookbooks/test/recipes/basic_site.rb
+++ b/test/cookbooks/test/recipes/basic_site.rb
@@ -1,7 +1,6 @@
 apache2_install 'default'
 
 service 'apache2' do
-  extend Apache2::Cookbook::Helpers
   service_name lazy { apache_platform_service_name }
   supports restart: true, status: true, reload: true
   action [:start, :enable]
@@ -18,13 +17,11 @@ end
 
 file "#{app_dir}/index.html" do
   content 'Hello World'
-  extend  Apache2::Cookbook::Helpers
   owner   lazy { default_apache_user }
   group   lazy { default_apache_group }
 end
 
 template 'basic_site' do
-  extend  Apache2::Cookbook::Helpers
   source 'basic_site.conf.erb'
   path "#{apache_dir}/sites-available/basic_site.conf"
   variables(

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -11,7 +11,6 @@ apache2_default_site '' do
 end
 
 service 'apache2' do
-  extend Apache2::Cookbook::Helpers
   service_name lazy { apache_platform_service_name }
   supports restart: true, status: true, reload: true
   action :nothing

--- a/test/cookbooks/test/recipes/mod_ssl.rb
+++ b/test/cookbooks/test/recipes/mod_ssl.rb
@@ -6,7 +6,6 @@ app_dir           = '/var/www/basic_site'
 apache2_install 'default'
 
 service 'apache2' do
-  extend Apache2::Cookbook::Helpers
   service_name lazy { apache_platform_service_name }
   supports restart: true, status: true, reload: true
   action [:start, :enable]
@@ -20,14 +19,12 @@ apache2_mod_ssl ''
 
 # Create Certificates
 directory '/home/apache2' do
-  extend    Apache2::Cookbook::Helpers
   owner     lazy { default_apache_user }
   group     lazy { default_apache_group }
   recursive true
 end
 
 directory app_dir do
-  extend    Apache2::Cookbook::Helpers
   owner     lazy { default_apache_user }
   group     lazy { default_apache_group }
   recursive true
@@ -35,7 +32,6 @@ end
 
 file "#{app_dir}/index.html" do
   content 'Hello World'
-  extend  Apache2::Cookbook::Helpers
   owner   lazy { default_apache_user }
   group   lazy { default_apache_group }
 end
@@ -62,7 +58,6 @@ end
 site_name = 'ssl_site'
 
 template site_name do
-  extend Apache2::Cookbook::Helpers
   source 'ssl.conf.erb'
   path "#{apache_dir}/sites-available/#{site_name}.conf"
   variables(

--- a/test/cookbooks/test/recipes/module_template.rb
+++ b/test/cookbooks/test/recipes/module_template.rb
@@ -1,7 +1,6 @@
 apache2_install 'default'
 
 service 'apache2' do
-  extend Apache2::Cookbook::Helpers
   service_name lazy { apache_platform_service_name }
   supports restart: true, status: true, reload: true
   action [:start, :enable]

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -1,11 +1,8 @@
-::Chef::DSL::Recipe.include Apache2::Cookbook::Helpers
-
 apache2_install 'default' do
   mpm 'prefork'
 end
 
 service 'apache2' do
-  extend Apache2::Cookbook::Helpers
   service_name lazy { apache_platform_service_name }
   supports restart: true, status: true, reload: true
   action [:start, :enable]

--- a/test/cookbooks/test/recipes/pkg_name.rb
+++ b/test/cookbooks/test/recipes/pkg_name.rb
@@ -13,7 +13,6 @@ apache2_default_site '' do
 end
 
 service 'apache2' do
-  extend Apache2::Cookbook::Helpers
   service_name lazy { apache_platform_service_name }
   supports restart: true, status: true, reload: true
   action :nothing


### PR DESCRIPTION
This removes the need to use `extend Apache2::Cookbook::Helpers` in resources
and `::Chef::DSL::Recipe.include Apache2::Cookbook::Helpers` in recipes.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

[Describe what this change achieves]

## Issues Resolved

[List any existing issues this PR resolves]

## Check List

- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
