### PR TITLE
Add apache namespace for `site_available?` and `site_enabled?` helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the apache2 cookbook.
 
+## Unreleased
+
+- Add apache namespace for `site_available?` and `site_enabled?` helper methods
+
 ## 8.5.0 (2020-09-22)
 
 - resolved cookstyle error: spec/libraries/default_modules_spec.rb:8:7 refactor: `ChefCorrectness/IncorrectLibraryInjection`

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -298,11 +298,11 @@ module Apache2
         ::File.symlink?("#{apache_dir}/mods-enabled/#{new_resource.name}.load")
       end
 
-      def site_enabled?(site_name)
+      def apache_site_enabled?(site_name)
         ::File.symlink?("#{apache_dir}/sites-enabled/#{site_name}.conf")
       end
 
-      def site_available?(site_name)
+      def apache_site_available?(site_name)
         ::File.exist?("#{apache_dir}/sites-available/#{site_name}.conf")
       end
 

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -8,8 +8,8 @@ action :enable do
   execute "a2ensite #{new_resource.site_name}" do
     command "/usr/sbin/a2ensite #{new_resource.site_name}"
     notifies :reload, 'service[apache2]', :delayed
-    not_if { site_enabled?(new_resource.site_name) }
-    only_if { site_available?(new_resource.site_name) }
+    not_if { apache_site_enabled?(new_resource.site_name) }
+    only_if { apache_site_available?(new_resource.site_name) }
   end
 end
 
@@ -17,7 +17,7 @@ action :disable do
   execute "a2dissite #{new_resource.site_name}" do
     command "/usr/sbin/a2dissite #{new_resource.site_name}"
     notifies :reload, 'service[apache2]', :delayed
-    only_if { site_enabled?(new_resource.site_name) }
+    only_if { apache_site_enabled?(new_resource.site_name) }
   end
 end
 


### PR DESCRIPTION
# Description

These two methods are conflicting with the nginx cookbook and need to be named
spaced. Rename them to have `apache_` prefixed.

These methods are only used internally so it shouldn't be a breaking change.

Signed-off-by: Lance Albertson <lance@osuosl.org>

## Issues Resolved

- Nginx and Apache cookbooks are able to run on the same server.

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
