### PR TITLE
Add `apache2_mod_wsgi` resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           - 'ports'
           - 'module-template'
           - 'mod-php'
+          - 'mod-wsgi'
           - 'pkg-name'
         exclude:
           - os: debian-9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the apache2 cookbook.
 
+## Unreleased
+
+- Add `apache2_mod_wsgi` resource
+
 ## 8.5.1 (2020-10-02)
 
 - Add apache namespace for `site_available?` and `site_enabled?` helper methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 ## Unreleased
 
 - Add `apache2_mod_wsgi` resource
+- Fix backwards compatibility for SUSE with `a2enmod`
 
 ## 8.5.1 (2020-10-02)
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Example wrapper cookbooks:
 - [mod](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod.md)
 - [module](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_module.md)
 - [mod_php](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod_php.md)
+- [mod_wsgi](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod_wsgi.md)
 
 ## Contributors
 

--- a/documentation/resource_apache2_mod_wsgi.md
+++ b/documentation/resource_apache2_mod_wsgi.md
@@ -2,7 +2,7 @@
 
 Enables apache2 module `mod_wsgi`.
 
-This resource will install and enable the Apache WSGI module. See `apache_mod_wsgi_package` for the platform-specific module package. By default it installs WSGI for Python 3 if available for the platform, otherwise falls back to Python 2. If installing Python and mod_wsgi outside of this resource, you should set `install_package` to `false` to avoid a possible version conflicts.
+This resource will install and enable the Apache WSGI module. See `apache_mod_wsgi_package` for the platform-specific module package. By default it installs WSGI for Python 3 if available for the platform, otherwise falls back to Python 2. If installing Python and mod_wsgi outside of this resource, you should set `install_package` to `false` to avoid a possible version conflict.
 
 **Note: call this resource directly, not through `apache2_module`!**
 This resource will call `_module` with the correct identifiers for you.

--- a/documentation/resource_apache2_mod_wsgi.md
+++ b/documentation/resource_apache2_mod_wsgi.md
@@ -1,0 +1,17 @@
+# apache2_mod_wsgi
+
+Enables apache2 module `mod_wsgi`.
+
+This resource will install and enable the Apache WSGI module. See `apache_mod_wsgi_package` for the platform-specific module package. By default it installs WSGI for Python 3 if available for the platform, otherwise falls back to Python 2. If installing Python and mod_wsgi outside of this resource, you should set `install_package` to `false` to avoid a possible version conflicts.
+
+**Note: call this resource directly, not through `apache2_module`!**
+This resource will call `_module` with the correct identifiers for you.
+
+## Properties
+
+| Name             | Type   | Default                      | Description                                       |
+| ---------------- | ------ | ---------------------------- | ------------------------------------------------- |
+| module_name      | String | `wsgi_module`                | The name of the wsgi module.                      |
+| so_filename      | String | `apache_mod_wsgi_filename`   | The filename of the module object.                |
+| package_name     | String | `apache_mod_wsgi_package`    | The package that contains the WSGI module itself. |
+| install_package  | Bool   | `true`                       | Whether to install the WSGI module package.       |

--- a/documentation/resource_apache2_mod_wsgi.md
+++ b/documentation/resource_apache2_mod_wsgi.md
@@ -1,3 +1,7 @@
+[back to resource list](https://github.com/sous-chefs/apache2#resources)
+
+---
+
 # apache2_mod_wsgi
 
 Enables apache2 module `mod_wsgi`.
@@ -6,6 +10,10 @@ This resource will install and enable the Apache WSGI module. See `apache_mod_ws
 
 **Note: call this resource directly, not through `apache2_module`!**
 This resource will call `_module` with the correct identifiers for you.
+
+## Actions
+
+- `:create`
 
 ## Properties
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -47,3 +47,6 @@ suites:
       - recipe[test::pkg_name]
     includes:
       - centos-7
+  - name: mod_wsgi
+    run_list:
+      - recipe[test::wsgi]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -392,6 +392,7 @@ module Apache2
         platform_family?('debian') ? "#{default_site_name}.conf.erb" : 'welcome.conf.erb'
       end
 
+      # mod_php
       def apache_mod_php_package
         case node['platform_family']
         when 'debian'
@@ -440,6 +441,32 @@ module Apache2
           'libphp5.so'
         when 'suse'
           'mod_php7.so'
+        end
+      end
+
+      # mod_wsgi
+      def apache_mod_wsgi_package
+        case node['platform_family']
+        when 'debian'
+          'libapache2-mod-wsgi-py3'
+        when 'amazon'
+          'mod_wsgi'
+        when 'rhel'
+          if node['platform_version'].to_i >= 8
+            'python3-mod_wsgi'
+          else
+            'mod_wsgi'
+          end
+        when 'suse'
+          'apache2-mod_wsgi-python3'
+        end
+      end
+
+      def apache_mod_wsgi_filename
+        if platform_family?('rhel') && node['platform_version'].to_i >= 8
+          'mod_wsgi_python3.so'
+        else
+          'mod_wsgi.so'
         end
       end
     end

--- a/resources/mod_wsgi.rb
+++ b/resources/mod_wsgi.rb
@@ -32,7 +32,6 @@ action :create do
   apache2_module 'wsgi' do
     identifier new_resource.module_name
     mod_name new_resource.so_filename
-    template_cookbook 'apache2'
     notifies :restart, 'service[apache2]'
   end
 end

--- a/resources/mod_wsgi.rb
+++ b/resources/mod_wsgi.rb
@@ -1,0 +1,38 @@
+property :name, String, default: ''
+
+property :module_name, String,
+         default: 'wsgi_module',
+         description: 'Module name for the Apache WSGI module.'
+
+property :so_filename, String,
+         default: lazy { apache_mod_wsgi_filename },
+         description: 'Filename for the module executable.'
+
+property :package_name, [String, Array],
+         default: lazy { apache_mod_wsgi_package },
+         description: 'Package that contains the Apache WSGI module itself'
+
+property :install_package, [true, false],
+         default: true,
+         description: 'Whether to install the Apache WSGI module package'
+
+action :create do
+  # install mod_wsgi package (if requested)
+  package new_resource.package_name do
+    only_if { new_resource.install_package }
+    notifies :delete, 'directory[purge distro conf.modules.d]', :immediately
+  end
+
+  directory 'purge distro conf.modules.d' do
+    path "#{apache_dir}/conf.modules.d"
+    recursive true
+    action :nothing
+  end
+
+  apache2_module 'wsgi' do
+    identifier new_resource.module_name
+    mod_name new_resource.so_filename
+    template_cookbook 'apache2'
+    notifies :restart, 'service[apache2]'
+  end
+end

--- a/spec/libraries/mod_wsgi_spec.rb
+++ b/spec/libraries/mod_wsgi_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+RSpec.describe Apache2::Cookbook::Helpers do
+  class DummyClass < Chef::Node
+    include Apache2::Cookbook::Helpers
+  end
+
+  subject { DummyClass.new }
+
+  describe '#apache_mod_wsgi_package' do
+    before do
+      allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
+      allow(subject).to receive(:[]).with(:platform_family).and_return(platform_family)
+      allow(subject).to receive(:[]).with('platform_version').and_return(platform_version)
+    end
+
+    context 'redhat 8' do
+      let(:platform_family) { 'rhel' }
+      let(:platform_version) { '8.2.2004' }
+      it { expect(subject.apache_mod_wsgi_package).to eq 'python3-mod_wsgi' }
+    end
+
+    context 'redhat 7' do
+      let(:platform_family) { 'rhel' }
+      let(:platform_version) { '7.7.1908' }
+      it { expect(subject.apache_mod_wsgi_package).to eq 'mod_wsgi' }
+    end
+
+    context 'debian' do
+      let(:platform_family) { 'debian' }
+      let(:platform_version) { '10' }
+      it { expect(subject.apache_mod_wsgi_package).to eq 'libapache2-mod-wsgi-py3' }
+    end
+
+    context 'ubuntu' do
+      let(:platform_family) { 'debian' }
+      let(:platform_version) { '20.04' }
+      it { expect(subject.apache_mod_wsgi_package).to eq 'libapache2-mod-wsgi-py3' }
+    end
+
+    context 'amazonlinux' do
+      let(:platform_family) { 'amazon' }
+      let(:platform_version) { '2018.03' }
+      it { expect(subject.apache_mod_wsgi_package).to eq 'mod_wsgi' }
+    end
+
+    context 'suse' do
+      let(:platform_family) { 'suse' }
+      let(:platform_version) { '15.1' }
+      it { expect(subject.apache_mod_wsgi_package).to eq 'apache2-mod_wsgi-python3' }
+    end
+  end
+
+  describe '#apache_mod_wsgi_filename' do
+    before do
+      allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
+      allow(subject).to receive(:[]).with(:platform_family).and_return(platform_family)
+      allow(subject).to receive(:[]).with('platform_version').and_return(platform_version)
+    end
+
+    context 'redhat 8' do
+      let(:platform_family) { 'rhel' }
+      let(:platform_version) { '8.2.2004' }
+      it { expect(subject.apache_mod_wsgi_filename).to eq 'mod_wsgi_python3.so' }
+    end
+
+    context 'redhat 7' do
+      let(:platform_family) { 'rhel' }
+      let(:platform_version) { '7.7.1908' }
+      it { expect(subject.apache_mod_wsgi_filename).to eq 'mod_wsgi.so' }
+    end
+
+    context 'debian' do
+      let(:platform_family) { 'debian' }
+      let(:platform_version) { '10' }
+      it { expect(subject.apache_mod_wsgi_filename).to eq 'mod_wsgi.so' }
+    end
+
+    context 'ubuntu' do
+      let(:platform_family) { 'debian' }
+      let(:platform_version) { '20.04' }
+      it { expect(subject.apache_mod_wsgi_filename).to eq 'mod_wsgi.so' }
+    end
+
+    context 'amazonlinux' do
+      let(:platform_family) { 'amazon' }
+      let(:platform_version) { '2018.03' }
+      it { expect(subject.apache_mod_wsgi_filename).to eq 'mod_wsgi.so' }
+    end
+
+    context 'suse' do
+      let(:platform_family) { 'suse' }
+      let(:platform_version) { '15.1' }
+      it { expect(subject.apache_mod_wsgi_filename).to eq 'mod_wsgi.so' }
+    end
+  end
+end

--- a/spec/resources/mod_wsgi_spec.rb
+++ b/spec/resources/mod_wsgi_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe 'apache2_mod_wsgi' do
+  step_into :apache2_install, :apache2_mod_wsgi, :apache2_module
+
+  platform 'ubuntu'
+
+  context 'Setup and enable WSGI module' do
+    recipe do
+      apache2_install 'wsgitest'
+      apache2_mod_wsgi 'wsgitest'
+    end
+
+    before do
+      stub_command('/usr/sbin/apache2ctl -t').and_return('foo')
+    end
+
+    it do
+      is_expected.to install_package('libapache2-mod-wsgi-py3')
+    end
+
+    it do
+      is_expected.to enable_apache2_module('wsgi').with(
+        identifier: 'wsgi_module',
+        mod_name: 'mod_wsgi.so'
+      )
+    end
+  end
+
+  context 'Enable WSGI module with custom properties' do
+    recipe do
+      apache2_install 'wsgicustom'
+      apache2_mod_wsgi 'wsgicustom' do
+        module_name 'wsgitest_module'
+        so_filename 'libwsgitest.so'
+        package_name 'mod_wsgitest'
+      end
+    end
+
+    before do
+      stub_command('/usr/sbin/apache2ctl -t').and_return('foo')
+    end
+
+    it do
+      is_expected.to install_package('mod_wsgitest')
+    end
+
+    it do
+      is_expected.to enable_apache2_module('wsgi').with(
+        identifier: 'wsgitest_module',
+        mod_name: 'libwsgitest.so'
+      )
+    end
+  end
+
+  context 'Do not install module package' do
+    recipe do
+      apache2_install 'wsgicustom'
+      apache2_mod_wsgi 'wsgicustom' do
+        package_name 'mod_wsgitest'
+        install_package false
+      end
+    end
+
+    before do
+      stub_command('/usr/sbin/apache2ctl -t').and_return('foo')
+    end
+
+    it do
+      is_expected.to_not install_package('mod_wsgitest')
+    end
+  end
+end

--- a/templates/a2enmod.erb
+++ b/templates/a2enmod.erb
@@ -16,13 +16,15 @@ my $quiet;
 my $force;
 my $maintmode;
 my $purge;
+my $delete;
 
 Getopt::Long::Configure('bundling');
 GetOptions(
     'quiet|q'     => \$quiet,
     'force|f'     => \$force,
     'maintmode|m' => \$maintmode,
-    'purge|p'     => \$purge
+    'purge|p'     => \$purge,
+    'd'           => \$delete
 ) or exit 2;
 
 my $basename = basename($0);
@@ -76,6 +78,13 @@ my $linkdir = File::Spec->abs2rel( $availdir, $enabldir );
 my $request_reload = 0;
 
 my $rc = 0;
+
+# Fix backwards compatibility for SUSE
+if ( -e "/usr/bin/zypper" ) {
+  if ( $quiet || $delete ) {
+    exit 0
+  }
+}
 
 if ( !scalar @ARGV ) {
     my @choices = myglob('*');

--- a/templates/a2enmod.erb
+++ b/templates/a2enmod.erb
@@ -24,7 +24,7 @@ GetOptions(
     'force|f'     => \$force,
     'maintmode|m' => \$maintmode,
     'purge|p'     => \$purge,
-    'd'           => \$delete
+    'delete|d'    => \$delete
 ) or exit 2;
 
 my $basename = basename($0);

--- a/test/cookbooks/test/files/test.wsgi
+++ b/test/cookbooks/test/files/test.wsgi
@@ -1,0 +1,7 @@
+def application(environ, start_response):
+    status = '200 OK'
+    output = b'Hello World!\n'
+    response_headers = [('Content-type', 'text/plain'),
+                        ('Content-Length', str(len(output)))]
+    start_response(status, response_headers)
+    return [output]

--- a/test/cookbooks/test/recipes/wsgi.rb
+++ b/test/cookbooks/test/recipes/wsgi.rb
@@ -1,0 +1,50 @@
+apache2_install 'default' do
+  mpm 'prefork'
+end
+
+service 'apache2' do
+  service_name lazy { apache_platform_service_name }
+  supports restart: true, status: true, reload: true
+  action [:start, :enable]
+end
+
+apache2_mod_wsgi
+
+# Required for hello world on suse
+package 'python3-webencodings' if platform_family?('suse')
+
+app_dir = '/var/www/wsgi_site/htdocs'
+wsgi_dir = '/var/www/wsgi_site/wsgi-scripts'
+
+directory app_dir do
+  recursive true
+end
+
+directory wsgi_dir do
+  recursive true
+end
+
+cookbook_file "#{wsgi_dir}/test.wsgi" do
+  notifies :restart, 'service[apache2]'
+end
+
+template 'wsgi_site' do
+  source 'wsgi_site.conf.erb'
+  path "#{apache_dir}/sites-available/wsgi_site.conf"
+  variables(
+    server_name: '127.0.0.1',
+    document_root: app_dir,
+    wsgi_root: wsgi_dir,
+    log_dir: lazy { default_log_dir },
+    site_name: 'wsgi_site'
+  )
+  notifies :restart, 'service[apache2]'
+end
+
+apache2_site 'wsgi_site' do
+  notifies :restart, 'service[apache2]'
+end
+
+apache2_site '000-default' do
+  action :disable
+end

--- a/test/cookbooks/test/templates/wsgi_site.conf.erb
+++ b/test/cookbooks/test/templates/wsgi_site.conf.erb
@@ -1,0 +1,32 @@
+<VirtualHost *:80>
+  ServerName <%= @server_name %>
+  DocumentRoot <%= @document_root %>
+
+  <Directory <%= @document_root %>>
+    Options FollowSymLinks
+    AllowOverride None
+    Require all granted
+  </Directory>
+
+  WSGIScriptAlias / <%= @wsgi_root %>/test.wsgi
+
+  <Directory <%= @wsgi_root %>>
+    Options FollowSymLinks
+    AllowOverride None
+    Require all granted
+  </Directory>
+
+  <Directory />
+    Options FollowSymLinks
+    AllowOverride None
+  </Directory>
+
+  <Location /server-status>
+    SetHandler server-status
+    Require local
+  </Location>
+
+  LogLevel info
+  ErrorLog <%= @log_dir %>/<%= @site_name %>-error.log
+  CustomLog <%= @log_dir %>/<%= @site_name %>-access.log combined
+</VirtualHost>

--- a/test/integration/mod_wsgi/controls/default.rb
+++ b/test/integration/mod_wsgi/controls/default.rb
@@ -1,0 +1,17 @@
+include_controls 'apache2-integration-tests' do
+  skip_control 'welcome-page'
+end
+
+control 'WSGI module enabled & running' do
+  impact 1
+  desc 'wsgi module should be enabled with config'
+
+  describe command('apachectl -M') do
+    its('stdout') { should match(/wsgi_module/) }
+  end
+
+  describe http('localhost') do
+    its('status') { should eq 200 }
+    its('body') { should match /Hello World!/ }
+  end
+end

--- a/test/integration/mod_wsgi/inspec.yml
+++ b/test/integration/mod_wsgi/inspec.yml
@@ -1,0 +1,11 @@
+---
+name: apache2-integration-tests
+title: Integration tests for apache2 cookbook
+summary: This InSpec profile contains integration tests for apache2 cookbook
+supports:
+  - os-family: linux
+  - os-family: bsd
+
+depends:
+  - name: apache2-integration-tests
+    path: test/integration/default


### PR DESCRIPTION
# Description

This adds a `apache2_mod_wsgi` resource to automate installation of `mod_wsgi` on supported platforms.

In addition, this fixes backwards compatibility for SUSE with `a2enmod`.     SUSE uses `a2enmod` in `postin` and `postun` scripts which breaks package installation when using this cookbook due to the fact we override this binary with our version.
    
This quietly ensures that `postin` and `postun` scripts pass without any error on SUSE.


## Issues Resolved

[List any existing issues this PR resolves]

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
