### PR TITLE
[GH-726] Add template_cookbook property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the apache2 cookbook.
 
+## Unreleased
+
+- Add `template_cookbook` property to `install`
+
 ## 8.6.0 (2020-10-13)
 
 - Add `apache2_mod_wsgi` resource

--- a/documentation/resource_apache2_install.md
+++ b/documentation/resource_apache2_install.md
@@ -27,12 +27,14 @@ Installs apache2.
 | keep_alive_timeout          | Integer         | `5`                                 | KeepAliveTimeout                                                                                               |
 | access_file_name            | String          | `.htaccess`                         | Access filename                                                                                                |
 | sysconfig_additional_params | Hash            | `{}`                                | Hash of additional sysconfig parameters to apply to the system                                                 |
+| template_cookbook           | String          | `apache2`                           | Cookbook to source the apache2.conf template from                                                              |
 
 ## Examples
 
 ```ruby
 apache2_install 'custom' do
   status_url 'status.site.org'
+  template_cookbook 'my_cookbook'
 end
 ```
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -24,29 +24,32 @@ platforms:
   - name: ubuntu-20.04
 
 suites:
-  - name: default
-    run_list:
-      - recipe[test::default]
-  - name: basic_site
-    run_list:
-      - recipe[test::basic_site]
-  - name: ssl
-    run_list:
-      - recipe[test::mod_ssl]
-  - name: ports
-    run_list:
-      - recipe[test::ports]
-  - name: module_template
-    run_list:
-      - recipe[test::module_template]
-  - name: mod_php
-    run_list:
-      - recipe[test::php]
-  - name: pkg_name
-    run_list:
-      - recipe[test::pkg_name]
-    includes:
-      - centos-7
-  - name: mod_wsgi
-    run_list:
-      - recipe[test::wsgi]
+   - name: default
+     run_list:
+       - recipe[test::default]
+   - name: custom_template
+     run_list:
+       - recipe[test::custom_template]
+   - name: basic_site
+     run_list:
+       - recipe[test::basic_site]
+   - name: ssl
+     run_list:
+       - recipe[test::mod_ssl]
+   - name: ports
+     run_list:
+       - recipe[test::ports]
+   - name: module_template
+     run_list:
+       - recipe[test::module_template]
+   - name: mod_php
+     run_list:
+       - recipe[test::php]
+   - name: pkg_name
+     run_list:
+       - recipe[test::pkg_name]
+     includes:
+       - centos-7
+   - name: mod_wsgi
+     run_list:
+       - recipe[test::wsgi]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -24,32 +24,32 @@ platforms:
   - name: ubuntu-20.04
 
 suites:
-   - name: default
-     run_list:
-       - recipe[test::default]
-   - name: custom_template
-     run_list:
-       - recipe[test::custom_template]
-   - name: basic_site
-     run_list:
-       - recipe[test::basic_site]
-   - name: ssl
-     run_list:
-       - recipe[test::mod_ssl]
-   - name: ports
-     run_list:
-       - recipe[test::ports]
-   - name: module_template
-     run_list:
-       - recipe[test::module_template]
-   - name: mod_php
-     run_list:
-       - recipe[test::php]
-   - name: pkg_name
-     run_list:
-       - recipe[test::pkg_name]
-     includes:
-       - centos-7
-   - name: mod_wsgi
-     run_list:
-       - recipe[test::wsgi]
+  - name: default
+    run_list:
+      - recipe[test::default]
+  - name: custom_template
+    run_list:
+      - recipe[test::custom_template]
+  - name: basic_site
+    run_list:
+      - recipe[test::basic_site]
+  - name: ssl
+    run_list:
+      - recipe[test::mod_ssl]
+  - name: ports
+    run_list:
+      - recipe[test::ports]
+  - name: module_template
+    run_list:
+      - recipe[test::module_template]
+  - name: mod_php
+    run_list:
+      - recipe[test::php]
+  - name: pkg_name
+    run_list:
+      - recipe[test::pkg_name]
+    includes:
+      - centos-7
+  - name: mod_wsgi
+    run_list:
+      - recipe[test::wsgi]

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -111,7 +111,11 @@ property :timeout, [Integer, String],
 
 property :sysconfig_additional_params, Hash,
          description: 'Hash of additional sysconfig parameters to apply to the system'
-
+           
+property :template_cookbook, String,
+         default: 'apache2',
+         description: 'Cookbook to source the template from. Override this to provide your own template'
+           
 action :install do
   package [new_resource.apache_pkg, perl_pkg] do
     version [new_resource.apache_version, nil] unless new_resource.apache_version.empty?
@@ -286,6 +290,7 @@ action :install do
     docroot_dir new_resource.docroot_dir
     timeout new_resource.timeout
     server_name new_resource.server_name
+    template_cookbook new_resource.template_cookbook
   end
 
   apache2_conf 'security'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -111,11 +111,11 @@ property :timeout, [Integer, String],
 
 property :sysconfig_additional_params, Hash,
          description: 'Hash of additional sysconfig parameters to apply to the system'
-           
+
 property :template_cookbook, String,
          default: 'apache2',
          description: 'Cookbook to source the template from. Override this to provide your own template'
-           
+
 action :install do
   package [new_resource.apache_pkg, perl_pkg] do
     version [new_resource.apache_version, nil] unless new_resource.apache_version.empty?

--- a/spec/resources/install_spec.rb
+++ b/spec/resources/install_spec.rb
@@ -33,4 +33,41 @@ describe 'apache2_install' do
       )
     end
   end
+  context 'install apache2 with apache2.conf from custom cookbook' do
+    recipe do
+      apache2_install 'custom' do
+        template_cookbook 'test'
+      end
+    end
+
+    it 'render template properly' do
+      stub_command('/usr/sbin/apache2ctl -t').and_return('foo')
+
+      is_expected.to create_template('/etc/apache2/apache2.conf').with_variables(
+        access_file_name: '.htaccess',
+        apache_binary: '/usr/sbin/apache2',
+        apache_dir: '/etc/apache2',
+        apache_group: 'www-data',
+        apache_user: 'www-data',
+        docroot_dir: '/var/www/html',
+        error_log: 'error.log',
+        keep_alive: 'On',
+        max_keep_alive_requests: 100,
+        keep_alive_timeout: 5,
+        lock_dir: '/var/lock/apache2',
+        log_dir: '/var/log/apache2',
+        log_level: 'warn',
+        pid_file: '/var/run/apache2/apache2.pid',
+        run_dir: '/var/run/apache2',
+        server_name: 'localhost',
+        timeout: '300'
+      )
+    end
+
+    it 'has a configuration from custom cookbook' do
+      stub_command('/usr/sbin/apache2ctl -t').and_return('foo')
+      is_expected.to render_file('/etc/apache2/apache2.conf')
+        .with_content(/Use template_cookbook property in apache2_config or apache2_install to provide your own apache2.conf/)
+    end
+  end
 end

--- a/test/cookbooks/test/recipes/custom_template.rb
+++ b/test/cookbooks/test/recipes/custom_template.rb
@@ -1,0 +1,19 @@
+apt_update 'update'
+
+apache2_install 'default_install' do
+  template_cookbook 'test'
+end
+
+apache2_site '000-default' do
+  action :disable
+end
+
+apache2_default_site '' do
+  action :enable
+end
+
+service 'apache2' do
+  service_name lazy { apache_platform_service_name }
+  supports restart: true, status: true, reload: true
+  action :nothing
+end

--- a/test/cookbooks/test/templates/apache2.conf.erb
+++ b/test/cookbooks/test/templates/apache2.conf.erb
@@ -2,6 +2,7 @@
 #
 # Based on the Ubuntu 18.04 apache2.conf
 #
+# Use template_cookbook property in apache2_config or apache2_install to provide your own apache2.conf
 ServerRoot "<%= @apache_dir %>"
 
 #

--- a/test/integration/custom_template/controls/default_spec.rb
+++ b/test/integration/custom_template/controls/default_spec.rb
@@ -1,0 +1,87 @@
+control 'service' do
+  impact 1
+  desc 'Apache2 service is running'
+
+  case os[:family]
+  when 'debian', 'suse'
+    describe service('apache2') do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+  when 'freebsd'
+    describe service('apache24') do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+  else
+    describe service('httpd') do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+  end
+end
+
+control 'welcome-page' do
+  impact 1
+  desc 'Apache2 Welcome Pages Displayed'
+
+  case os[:family]
+  when 'debian'
+    describe http('localhost') do
+      its('status') { should eq 200 }
+      its('body') { should cmp /This is the default welcome page/ }
+    end
+  when 'freebsd'
+    describe http('localhost') do
+      its('status') { should eq 200 }
+      its('body') { should_not cmp /Forbidden/ }
+    end
+  when 'suse'
+    describe http('localhost') do
+      its('status') { should eq 403 }
+      its('body') { should cmp /Forbidden/ }
+      its('body') { should cmp /Apache Server/ }
+    end
+  else
+    describe http('localhost') do
+      its('status') { should eq 403 }
+      its('body') { should_not cmp /Forbidden/ }
+      its('body') { should cmp /powered by CentOS/ }
+    end
+  end
+end
+
+control 'template-render' do
+  case os[:family]
+  when 'debian'
+    describe file('/etc/apache2/apache2.conf') do
+      it { should exist }
+      its('content') { should match(/Use template_cookbook property in apache2_config or apache2_install to provide your own apache2.conf/) }
+    end
+  when 'suse'
+    describe file('/etc/apache2/httpd.conf') do
+      it { should exist }
+      its('content') { should match(/Use template_cookbook property in apache2_config or apache2_install to provide your own apache2.conf/) }
+    end
+  when 'freebsd'
+    describe file('/usr/local/etc/apache2/httpd.conf') do
+      it { should exist }
+      its('content') { should match(/Use template_cookbook property in apache2_config or apache2_install to provide your own apache2.conf/) }
+    end
+  else
+    describe file('/etc/httpd/conf/httpd.conf') do
+      it { should exist }
+      its('content') { should match(/Use template_cookbook property in apache2_config or apache2_install to provide your own apache2.conf/) }
+    end
+  end
+end
+
+#  Disable until all platforms are pukka
+# include_controls 'dev-sec/apache-baseline' do
+#   skip_control 'apache-05' # We don't have hardening.conf
+#   skip_control 'apache-10' # We don't have hardening.conf
+#   skip_control 'apache-13' # We don't enable SSL by defauly (yet)
+# end

--- a/test/integration/custom_template/inspec.yml
+++ b/test/integration/custom_template/inspec.yml
@@ -1,0 +1,11 @@
+---
+name: apache2-integration-tests
+title: Integration tests for apache2 cookbook
+summary: This InSpec profile contains integration tests for apache2 cookbook
+supports:
+  - os-family: linux
+  - os-family: bsd
+
+# depends:
+# - name:  dev-sec/apache-baseline
+#   supermarket: dev-sec/apache-baseline


### PR DESCRIPTION
# Description

Provide template_cookbook property to enable passing own template for httpd.conf/apache2.conf in apache2_install

## Issues Resolved

#726 

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
