### PR TITLE
Allow custom settings in `apache2_conf` templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- Enable `options` property to pass arbitrary variables to the conf template
+
 ## 8.8.0 - *2021-01-26*
 
 - Remove support and testing for Ubuntu 16.04

--- a/documentation/resource_apache2_conf.md
+++ b/documentation/resource_apache2_conf.md
@@ -9,6 +9,7 @@ Writes conf files to the `conf-available` folder, and passes enabled values to `
 | path              | String | `"#{apache_dir}/conf-available"` | Path to the conf-available directory                                               |
 | root_group        | String | `node['root_group']`             | Platform based default for the templates root group.                               |
 | template_cookbook | String | apache2                          | Cookbook to source the template from.  Override this to provide your own template. |
+| options           | Hash   | `node['root_group']`             | Hash of key-value pairs to pass to the template (useful for overridden templates)  |
 
 ### Examples
 
@@ -31,5 +32,17 @@ Place the example conf, which has a different path than the default (conf-*):
 ```ruby
 apache2_conf 'example' do
   path '/random/example/path'
+end
+```
+
+Use a custom template with discrete variables:
+
+```ruby
+apache2_conf 'my_custom_conf' do
+  template_cookbook 'my_cookbook'
+  options(
+    index_ignore: ". .secret *.gen"
+    index_charset: "UTF-8"
+  )
 end
 ```

--- a/documentation/resource_apache2_conf.md
+++ b/documentation/resource_apache2_conf.md
@@ -9,7 +9,7 @@ Writes conf files to the `conf-available` folder, and passes enabled values to `
 | path              | String | `"#{apache_dir}/conf-available"` | Path to the conf-available directory                                               |
 | root_group        | String | `node['root_group']`             | Platform based default for the templates root group.                               |
 | template_cookbook | String | apache2                          | Cookbook to source the template from.  Override this to provide your own template. |
-| options           | Hash   | `node['root_group']`             | Hash of key-value pairs to pass to the template (useful for overridden templates)  |
+| options           | Hash   | server_tokens: 'Prod', server_signature: 'On', trace_enable: 'Off',             | Hash of key-value pairs to pass to the template (useful for overridden templates)  |
 
 ### Examples
 

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -27,7 +27,7 @@ action :enable do
     group new_resource.root_group
     backup false
     mode '0644'
-    variables new_resource.options.merge({apache_dir: apache_dir})
+    variables new_resource.options.merge({ apache_dir: apache_dir })
     notifies :restart, 'service[apache2]', :delayed
   end
 

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -27,12 +27,7 @@ action :enable do
     group new_resource.root_group
     backup false
     mode '0644'
-    variables(
-      apache_dir: apache_dir,
-      server_tokens: new_resource.options[:server_tokens],
-      server_signature: new_resource.options[:server_signature],
-      trace_enable: new_resource.options[:trace_enable]
-    )
+    variables new_resource.options.merge({apache_dir: apache_dir})
     notifies :restart, 'service[apache2]', :delayed
   end
 

--- a/test/cookbooks/test/recipes/custom_template.rb
+++ b/test/cookbooks/test/recipes/custom_template.rb
@@ -12,6 +12,14 @@ apache2_default_site '' do
   action :enable
 end
 
+apache2_conf 'custom' do
+  template_cookbook 'test'
+  options(
+    index_ignore: '. .secret *.gen',
+    index_charset: 'UTF-8'
+  )
+end
+
 service 'apache2' do
   service_name lazy { apache_platform_service_name }
   supports restart: true, status: true, reload: true

--- a/test/cookbooks/test/templates/custom.conf.erb
+++ b/test/cookbooks/test/templates/custom.conf.erb
@@ -1,0 +1,5 @@
+# This is a custom config with arbitrary settings
+IndexIgnore <%= @index_ignore %>
+
+# maybe add another setting here ?
+IndexOptions Charset=<%= @index_charset %>

--- a/test/integration/custom_template/controls/default_spec.rb
+++ b/test/integration/custom_template/controls/default_spec.rb
@@ -79,6 +79,35 @@ control 'template-render' do
   end
 end
 
+control 'custom-conf' do
+  case os[:family]
+  when 'debian'
+    describe file('/etc/apache2/conf-enabled/custom.conf') do
+      it { should exist }
+      its('content') { should include 'IndexIgnore . .secret *.gen' }
+      its('content') { should include 'IndexOptions Charset=UTF-8' }
+    end
+  when 'suse'
+    describe file('/etc/apache2/conf-enabled/custom.conf') do
+      it { should exist }
+      its('content') { should include 'IndexIgnore . .secret *.gen' }
+      its('content') { should include 'IndexOptions Charset=UTF-8' }
+    end
+  when 'freebsd'
+    describe file('/usr/local/etc/apache2/conf-enabled/custom.conf') do
+      it { should exist }
+      its('content') { should include 'IndexIgnore . .secret *.gen' }
+      its('content') { should include 'IndexOptions Charset=UTF-8' }
+    end
+  else
+    describe file('/etc/httpd/conf/conf-enabled/custom.conf') do
+      it { should exist }
+      its('content') { should include 'IndexIgnore . .secret *.gen' }
+      its('content') { should include 'IndexOptions Charset=UTF-8' }
+    end
+  end
+end
+
 #  Disable until all platforms are pukka
 # include_controls 'dev-sec/apache-baseline' do
 #   skip_control 'apache-05' # We don't have hardening.conf


### PR DESCRIPTION
Using the now documented `options` property of the `conf` resource, it
is now possible to pass arbitrary values to the underlying template.
This is most useful when the conf template is overridden via
template_cookbook (taken from one's own cookbook and not from the apache2 cookbook)

Example:

recipe.rb
```ruby
apache2_conf 'custom' do
  template_cookbook 'test'
  options(
    index_ignore: '. .secret *.gen',
    index_charset: 'UTF-8'
  )
end
```

custom.conf.erb
```ruby
# This is a custom config with arbitrary settings
IndexIgnore <%= @index_ignore %>

# maybe add another setting here ?
IndexOptions Charset=<%= @index_charset %>

```
Signed-off-by: Antoine Mazeas <antoine@karthanis.net>

# Description

It is now possible to have custom conf templates that will take arbitrary variables from the resource.

## Issues Resolved

Fix #729

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
   Some unrelated tests fail
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
    N/A; however the affected resource documentation has been amended.