### PR TITLE
Fix apache2_mod_auth_cas resource for all supported platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,21 +40,22 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'debian-9'
-          - 'debian-10'
           - 'centos-7'
           - 'centos-8'
-          - 'ubuntu-1804'
+          - 'debian-9'
+          - 'debian-10'
           - 'opensuse-leap-15'
+          - 'ubuntu-1804'
         suite:
-          - 'default'
           - 'basic-site'
-          - 'ssl'
-          - 'ports'
-          - 'module-template'
+          - 'default'
+          - 'mod-auth-cas'
           - 'mod-php'
+          - 'module-template'
           - 'mod-wsgi'
           - 'pkg-name'
+          - 'ports'
+          - 'ssl'
         exclude:
           - os: debian-9
             suite: pkg-name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- Fix `apache2_mod_auth_cas` resource for all supported platforms
+- Fix apache devel package name on SUSE platforms
+- Fix `libexec_dir` variable in `auth_cas.load` template
+- Add Integration tests for `apache2_mod_auth_cas` resource
+- Add docs for `apache2_mod_auth_cas`
+- Add `:source_checksum`, `:login_url`, `:validate_url` properties to `apache2_mod_auth_cas` resource
+- Allow `apache2_mod_auth_cas` resource to be nameless
+- Update `mod_auth_cas` source version to 1.2 and other various updates for source installations
+- Install `mod_auth_cas` by source on CentOS 8 and SUSE platforms (distro package is not currently available)
+- Include yum-epel recipe on RHEL/Amazon platforms
+
 ## 8.9.1 - *2021-03-03*
+
+- Fix url in README
 
 ## 8.9.0 - *2021-01-27*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 - Fix `libexec_dir` variable in `auth_cas.load` template
 - Add Integration tests for `apache2_mod_auth_cas` resource
 - Add docs for `apache2_mod_auth_cas`
-- Add `:source_checksum`, `:login_url`, `:validate_url` properties to `apache2_mod_auth_cas` resource
+- Add `:source_checksum`, `:login_url`, `:validate_url`, `:directives` properties to `apache2_mod_auth_cas` resource
 - Allow `apache2_mod_auth_cas` resource to be nameless
 - Update `mod_auth_cas` source version to 1.2 and other various updates for source installations
 - Install `mod_auth_cas` by source on CentOS 8 and SUSE platforms (distro package is not currently available)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Example wrapper cookbooks:
 - [module](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_module.md)
 - [mod_php](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod_php.md)
 - [mod_wsgi](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod_wsgi.md)
+- [mod_auth_cas](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod_auth_cas.md)
 
 ## Contributors
 

--- a/documentation/resource_apache2_mod_auth_cas.md
+++ b/documentation/resource_apache2_mod_auth_cas.md
@@ -1,0 +1,34 @@
+[back to resource list](https://github.com/sous-chefs/apache2#resources)
+
+---
+
+# apache2_mod_auth_cas
+
+Enables apache2 module `mod_auth_cas`.
+
+**Note: call this resource directly, not through `apache2_module`!**
+This resource will call `_module` with the correct identifiers for you.
+
+## Actions
+
+- `:create`
+
+## Properties
+
+| Name              | Type   | Default                                         | Description                                                   |
+| ----------------- | ------ | ----------------------------------------------- | ------------------------------------------------------------- |
+| `install_method`  | String | `apache_mod_auth_cas_install_method`            | Install method for Mod auth CAS                               |
+| `source_revision` | String | `v1.2`                                          | Revision for the mod auth cas source install                  |
+| `source_checksum` | String | (see resource default)                          | Checksum for the mod auth cas source install                  |
+| `login_url`       | String | `https://login.example.org/cas/login`           | The URL to redirect users when not already logged in.         |
+| `validate_url`    | String | `https://login.example.org/cas/serviceValidate` | The URL to use when validating a ticket presented by a client |
+| `root_group`      | String | `node['root_group']`                            | Group that the root user on the box runs as.                  |
+| `apache_user`     | String | `default_apache_user`                           | Set to override the default apache2 user.                     |
+| `apache_group`    | String | `default_apache_group`                          | Set to override the default apache2 user.                     |
+| `mpm`             | String | `default_mpm`                                   | Used to determine which devel package to install              |
+
+## Examples
+
+```ruby
+apache2_mod_auth_cas
+```

--- a/documentation/resource_apache2_mod_auth_cas.md
+++ b/documentation/resource_apache2_mod_auth_cas.md
@@ -15,20 +15,29 @@ This resource will call `_module` with the correct identifiers for you.
 
 ## Properties
 
-| Name              | Type   | Default                                         | Description                                                   |
-| ----------------- | ------ | ----------------------------------------------- | ------------------------------------------------------------- |
-| `install_method`  | String | `apache_mod_auth_cas_install_method`            | Install method for Mod auth CAS                               |
-| `source_revision` | String | `v1.2`                                          | Revision for the mod auth cas source install                  |
-| `source_checksum` | String | (see resource default)                          | Checksum for the mod auth cas source install                  |
-| `login_url`       | String | `https://login.example.org/cas/login`           | The URL to redirect users when not already logged in.         |
-| `validate_url`    | String | `https://login.example.org/cas/serviceValidate` | The URL to use when validating a ticket presented by a client |
-| `root_group`      | String | `node['root_group']`                            | Group that the root user on the box runs as.                  |
-| `apache_user`     | String | `default_apache_user`                           | Set to override the default apache2 user.                     |
-| `apache_group`    | String | `default_apache_group`                          | Set to override the default apache2 user.                     |
-| `mpm`             | String | `default_mpm`                                   | Used to determine which devel package to install              |
+| Name              | Type   | Default                                         | Description                                                                    |
+| ----------------- | ------ | ----------------------------------------------- | ------------------------------------------------------------------------------ |
+| `install_method`  | String | `apache_mod_auth_cas_install_method`            | Install method for Mod auth CAS                                                |
+| `source_revision` | String | `v1.2`                                          | Revision for the mod auth cas source install                                   |
+| `source_checksum` | String | (see resource default)                          | Checksum for the mod auth cas source install                                   |
+| `login_url`       | String | `https://login.example.org/cas/login`           | The URL to redirect users when not already logged in.                          |
+| `validate_url`    | String | `https://login.example.org/cas/serviceValidate` | The URL to use when validating a ticket presented by a client                  |
+| `root_group`      | String | `node['root_group']`                            | Group that the root user on the box runs as.                                   |
+| `apache_user`     | String | `default_apache_user`                           | Set to override the default apache2 user.                                      |
+| `apache_group`    | String | `default_apache_group`                          | Set to override the default apache2 user.                                      |
+| `mpm`             | String | `default_mpm`                                   | Used to determine which devel package to install                               |
+| `directives`      | Hash   | `nil`                                           | Hash of optional directives to pass to the `mod_auth_cas module` configuration |
 
 ## Examples
 
 ```ruby
+# Default settings
 apache2_mod_auth_cas
+
+# Setting optional CAS directives
+apache2_mod_auth_cas 'default' do
+  directives(
+    'CASCookiePath' => "#{cache_dir}/mod_auth_cas/"
+  )
+end
 ```

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -52,3 +52,6 @@ suites:
   - name: mod_wsgi
     run_list:
       - recipe[test::wsgi]
+  - name: mod_auth_cas
+    run_list:
+      - recipe[test::auth_cas]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -320,6 +320,8 @@ module Apache2
           else
             'apache2-dev'
           end
+        when 'suse'
+          'apache2-devel'
         else
           'httpd-devel'
         end
@@ -467,6 +469,24 @@ module Apache2
           'mod_wsgi_python3.so'
         else
           'mod_wsgi.so'
+        end
+      end
+
+      def apache_mod_auth_cas_install_method
+        if (platform_family?('rhel') && node['platform_version'].to_i >= 8) || platform_family?('suse')
+          'source'
+        else
+          'package'
+        end
+      end
+
+      def apache_mod_auth_cas_devel_packages
+        if platform_family?('rhel', 'amazon')
+          %w(openssl-devel libcurl-devel pcre-devel libtool)
+        elsif platform_family?('debian')
+          %w(libssl-dev libcurl4-openssl-dev libpcre++-dev libtool)
+        elsif platform_family?('suse')
+          %w(libopenssl-devel libcurl-devel pcre-devel libtool)
         end
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,8 @@ license          'Apache-2.0'
 description      'Installs and configures apache2'
 version          '8.9.1'
 
+depends 'yum-epel'
+
 supports 'debian'
 supports 'ubuntu'
 supports 'redhat'

--- a/resources/mod_auth_cas.rb
+++ b/resources/mod_auth_cas.rb
@@ -42,6 +42,9 @@ property :mpm, String,
          default: lazy { default_mpm },
          description: 'Apache2 MPM: used to determine which devel package to install on Debian'
 
+property :directives, Hash,
+        description: 'Hash of optional directives to pass to the mod_auth_cas module configuration'
+
 action :install do
   if new_resource.install_method.eql? 'source'
     package [apache_devel_package(new_resource.mpm), apache_mod_auth_cas_devel_packages].flatten
@@ -112,7 +115,8 @@ action :install do
     mod_conf(
       cache_dir: cache_dir,
       login_url: new_resource.login_url,
-      validate_url: new_resource.validate_url
+      validate_url: new_resource.validate_url,
+      directives: new_resource.directives
     )
   end
 

--- a/resources/mod_auth_cas.rb
+++ b/resources/mod_auth_cas.rb
@@ -1,13 +1,27 @@
 unified_mode true
 
+property :name, String, default: ''
+
 property :install_method, String,
          equal_to: %w( source package ),
-         default: 'package',
+         default: lazy { apache_mod_auth_cas_install_method },
          description: 'Install method for Mod auth CAS'
 
 property :source_revision, String,
-         default: 'v1.0.9.1',
+         default: 'v1.2',
          description: 'Revision for the mod auth cas source install'
+
+property :source_checksum, String,
+         default: 'b05a194f6c255f65a10537242648d8c0c2110960c03aff240bd8f52eaa454c29',
+         description: 'Checksum for the mod auth cas source install'
+
+property :login_url, String,
+         default: 'https://login.example.org/cas/login',
+         description: 'The URL to redirect users to when they attempt to access a CAS protected resource and do not have an existing session.'
+
+property :validate_url, String,
+         default: 'https://login.example.org/cas/serviceValidate',
+         description: 'The URL to use when validating a ticket presented by a client'
 
 property :root_group, String,
          default: lazy { node['root_group'] },
@@ -30,18 +44,26 @@ property :mpm, String,
 
 action :install do
   if new_resource.install_method.eql? 'source'
-    package apache_devel_package(new_resource.mpm)
+    package [apache_devel_package(new_resource.mpm), apache_mod_auth_cas_devel_packages].flatten
 
-    git '/tmp/mod_auth_cas' do
-      repository 'git://github.com/Jasig/mod_auth_cas.git'
-      revision new_resource.source_revision
+    build_essential 'mod_auth_cas'
+
+    mod_auth_cas_tarball = "#{Chef::Config[:file_cache_path]}/mod_auth_cas.tar.gz"
+
+    remote_file mod_auth_cas_tarball do
+      source "https://github.com/apereo/mod_auth_cas/archive/#{new_resource.source_revision}.tar.gz"
+      checksum new_resource.source_checksum
+    end
+
+    archive_file mod_auth_cas_tarball do
+      destination "#{Chef::Config[:file_cache_path]}/mod_auth_cas"
       notifies :run, 'execute[compile mod_auth_cas]', :immediately
     end
 
     execute 'compile mod_auth_cas' do
-      command './configure && make && make install'
-      cwd '/tmp/mod_auth_cas'
-      not_if "test -f #{apache_libexec_dir}/mod_auth_cas.so"
+      command 'autoreconf -ivf && ./configure && make && make install'
+      cwd "#{Chef::Config[:file_cache_path]}/mod_auth_cas/mod_auth_cas-#{new_resource.source_revision.gsub(/^v/, '')}"
+      not_if { ::File.exist?("#{apache_libexec_dir}/mod_auth_cas.so") }
     end
 
     template "#{apache_dir}/mods-available/auth_cas.load" do
@@ -49,7 +71,7 @@ action :install do
       source 'mods/auth_cas.load.erb'
       owner 'root'
       group new_resource.root_group
-      variables(cache_dir: cache_dir)
+      variables(cache_dir: cache_dir, libexec_dir: apache_libexec_dir)
       mode '0644'
     end
   else
@@ -58,10 +80,24 @@ action :install do
     when 'debian'
       package 'libapache2-mod-auth-cas'
     when 'rhel', 'fedora', 'amazon'
-      with_run_context :root do
-        yum_package 'mod_auth_cas' do
-          notifies :run, 'execute[generate-module-list]', :immediately
-        end
+      include_recipe 'yum-epel' unless platform_family?('fedora')
+
+      yum_package 'mod_auth_cas' do
+        notifies :run, 'execute[generate-module-list]', :immediately
+        notifies :delete, 'directory[purge distro conf.modules.d]', :immediately
+        notifies :delete, 'directory[purge distro conf.d]', :immediately
+      end
+
+      directory 'purge distro conf.modules.d' do
+        path "#{apache_dir}/conf.modules.d"
+        recursive true
+        action :nothing
+      end
+
+      directory 'purge distro conf.d' do
+        path "#{apache_dir}/conf.d"
+        recursive true
+        action :nothing
       end
 
       file "#{apache_dir}/conf.d/auth_cas.conf" do
@@ -71,7 +107,14 @@ action :install do
     end
   end
 
-  apache2_module 'auth_cas'
+  apache2_module 'auth_cas' do
+    template_cookbook 'apache2'
+    mod_conf(
+      cache_dir: cache_dir,
+      login_url: new_resource.login_url,
+      validate_url: new_resource.validate_url
+    )
+  end
 
   directory "#{cache_dir}/mod_auth_cas" do
     owner new_resource.apache_user

--- a/resources/mod_auth_cas.rb
+++ b/resources/mod_auth_cas.rb
@@ -118,6 +118,7 @@ action :install do
       validate_url: new_resource.validate_url,
       directives: new_resource.directives
     )
+    notifies :reload, 'service[apache2]'
   end
 
   directory "#{cache_dir}/mod_auth_cas" do

--- a/spec/libraries/devel_package_spec.rb
+++ b/spec/libraries/devel_package_spec.rb
@@ -28,7 +28,7 @@ describe '#apache_devel_package' do
 
   context 'suse' do
     platform 'suse'
-    it { is_expected.to write_log('httpd-devel') }
+    it { is_expected.to write_log('apache2-devel') }
   end
 
   context 'freebsd' do

--- a/spec/libraries/mod_auth_cas_spec.rb
+++ b/spec/libraries/mod_auth_cas_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+RSpec.describe Apache2::Cookbook::Helpers do
+  class DummyClass < Chef::Node
+    include Apache2::Cookbook::Helpers
+  end
+
+  subject { DummyClass.new }
+
+  describe '#apache_mod_auth_cas_install_method' do
+    before do
+      allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
+      allow(subject).to receive(:[]).with(:platform_family).and_return(platform_family)
+      allow(subject).to receive(:[]).with('platform_version').and_return(platform_version)
+    end
+
+    context 'redhat 8' do
+      let(:platform_family) { 'rhel' }
+      let(:platform_version) { '8.2.2004' }
+      it { expect(subject.apache_mod_auth_cas_install_method).to eq 'source' }
+    end
+
+    context 'redhat 7' do
+      let(:platform_family) { 'rhel' }
+      let(:platform_version) { '7.7.1908' }
+      it { expect(subject.apache_mod_auth_cas_install_method).to eq 'package' }
+    end
+
+    context 'debian' do
+      let(:platform_family) { 'debian' }
+      let(:platform_version) { '10' }
+      it { expect(subject.apache_mod_auth_cas_install_method).to eq 'package' }
+    end
+
+    context 'ubuntu' do
+      let(:platform_family) { 'debian' }
+      let(:platform_version) { '20.04' }
+      it { expect(subject.apache_mod_auth_cas_install_method).to eq 'package' }
+    end
+
+    context 'amazonlinux' do
+      let(:platform_family) { 'amazon' }
+      let(:platform_version) { '2018.03' }
+      it { expect(subject.apache_mod_auth_cas_install_method).to eq 'package' }
+    end
+
+    context 'suse' do
+      let(:platform_family) { 'suse' }
+      let(:platform_version) { '15.1' }
+      it { expect(subject.apache_mod_auth_cas_install_method).to eq 'source' }
+    end
+  end
+
+  describe '#apache_mod_auth_cas_devel_packages' do
+    before do
+      allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
+      allow(subject).to receive(:[]).with(:platform_family).and_return(platform_family)
+      allow(subject).to receive(:[]).with('platform_version').and_return(platform_version)
+    end
+
+    context 'redhat 8' do
+      let(:platform_family) { 'rhel' }
+      let(:platform_version) { '8.2.2004' }
+      it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(openssl-devel libcurl-devel pcre-devel libtool) }
+    end
+
+    context 'redhat 7' do
+      let(:platform_family) { 'rhel' }
+      let(:platform_version) { '7.7.1908' }
+      it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(openssl-devel libcurl-devel pcre-devel libtool) }
+    end
+
+    context 'debian' do
+      let(:platform_family) { 'debian' }
+      let(:platform_version) { '10' }
+      it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(libssl-dev libcurl4-openssl-dev libpcre++-dev libtool) }
+    end
+
+    context 'ubuntu' do
+      let(:platform_family) { 'debian' }
+      let(:platform_version) { '20.04' }
+      it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(libssl-dev libcurl4-openssl-dev libpcre++-dev libtool) }
+    end
+
+    context 'amazonlinux' do
+      let(:platform_family) { 'amazon' }
+      let(:platform_version) { '2018.03' }
+      it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(openssl-devel libcurl-devel pcre-devel libtool) }
+    end
+
+    context 'suse' do
+      let(:platform_family) { 'suse' }
+      let(:platform_version) { '15.1' }
+      it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(libopenssl-devel libcurl-devel pcre-devel libtool) }
+    end
+  end
+end

--- a/spec/resources/mod_auth_cas_spec.rb
+++ b/spec/resources/mod_auth_cas_spec.rb
@@ -23,6 +23,7 @@ describe 'apache2_mod_auth_cas' do
           cache_dir: '/var/cache/apache2',
           login_url: 'https://login.example.org/cas/login',
           validate_url: 'https://login.example.org/cas/serviceValidate',
+          directives: nil,
         }
       )
     end

--- a/templates/mods/auth_cas.conf.erb
+++ b/templates/mods/auth_cas.conf.erb
@@ -1,3 +1,8 @@
 CASCookiePath <%= @cache_dir %>/mod_auth_cas/
 CASLoginURL <%= @login_url %>
 CASValidateURL <%= @validate_url %>
+<% unless @directives.nil? -%>
+<% @directives.sort_by { |key, val| key }.each do |directive, value| -%>
+<%= directive %> <%= value %>
+<% end -%>
+<% end -%>

--- a/templates/mods/auth_cas.conf.erb
+++ b/templates/mods/auth_cas.conf.erb
@@ -1,1 +1,3 @@
 CASCookiePath <%= @cache_dir %>/mod_auth_cas/
+CASLoginURL <%= @login_url %>
+CASValidateURL <%= @validate_url %>

--- a/test/cookbooks/test/recipes/auth_cas.rb
+++ b/test/cookbooks/test/recipes/auth_cas.rb
@@ -8,4 +8,8 @@ service 'apache2' do
   action [:start, :enable]
 end
 
-apache2_mod_auth_cas
+apache2_mod_auth_cas 'default' do
+  directives(
+    'CASCookiePath' => "#{cache_dir}/mod_auth_cas/"
+  )
+end

--- a/test/cookbooks/test/recipes/auth_cas.rb
+++ b/test/cookbooks/test/recipes/auth_cas.rb
@@ -1,0 +1,11 @@
+apache2_install 'default' do
+  mpm 'prefork'
+end
+
+service 'apache2' do
+  service_name lazy { apache_platform_service_name }
+  supports restart: true, status: true, reload: true
+  action [:start, :enable]
+end
+
+apache2_mod_auth_cas

--- a/test/integration/mod_auth_cas/controls/default.rb
+++ b/test/integration/mod_auth_cas/controls/default.rb
@@ -1,0 +1,12 @@
+include_controls 'apache2-integration-tests' do
+  skip_control 'welcome-page'
+end
+
+control 'auth_cas module enabled & running' do
+  impact 1
+  desc 'auth_cas module should be enabled with config'
+
+  describe command('apachectl -M') do
+    its('stdout') { should match(/auth_cas/) }
+  end
+end

--- a/test/integration/mod_auth_cas/inspec.yml
+++ b/test/integration/mod_auth_cas/inspec.yml
@@ -1,0 +1,11 @@
+---
+name: apache2-integration-tests
+title: Integration tests for apache2 cookbook
+summary: This InSpec profile contains integration tests for apache2 cookbook
+supports:
+  - os-family: linux
+  - os-family: bsd
+
+depends:
+  - name: apache2-integration-tests
+    path: test/integration/default


### PR DESCRIPTION
This resolves #735.

- Fix apache devel package name on SUSE platforms
- Fix `libexec_dir` variable in `auth_cas.load` template
- Add Integration tests for `apache2_mod_auth_cas` resource
- Add docs for `apache2_mod_auth_cas`
- Add `:source_checksum`, `:login_url`, `:validate_url` properties to `apache2_mod_auth_cas` resource
- Allow `apache2_mod_auth_cas` resource to be nameless
- Update `mod_auth_cas` source version to 1.2 and other various updates for source installations
- Install `mod_auth_cas` by source on CentOS 8 and SUSE platforms (distro package is not currently available)
- Include yum-epel recipe on RHEL/Amazon platforms

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

[Describe what this change achieves]

## Issues Resolved

[List any existing issues this PR resolves]

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
