### PR TITLE
Fix CentOS 8 welcome page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- Fix EL8 welcome page
+
 ## 8.11.1 - *2021-06-01*
 
 ## 8.11.0 - *2021-05-06*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## 8.11.1 - *2021-06-01*
 
+- Standardise files with files in sous-chefs/repo-management
+
 ## 8.11.0 - *2021-05-06*
 
 - Add missing unified_mode from mod_php and mod_wscgi

--- a/templates/welcome.conf.erb
+++ b/templates/welcome.conf.erb
@@ -48,11 +48,8 @@ DocumentRoot "<%= @docroot_dir %>"
 </Directory>
 
 <% if node['platform_version'].to_i == 8 -%>
-Alias /.noindex.html /usr/share/httpd/noindex/index.html.en-US
-Alias /noindex/css/bootstrap.min.css /usr/share/httpd/noindex/common/css/bootstrap.min.css
-Alias /noindex/css/open-sans.css /usr/share/httpd/noindex/common/css/styles.css
-Alias /noindex/common/images/pb-apache.png /usr/share/httpd/noindex/common/images/pb-apache.png
-Alias /noindex/common/images/pb-centos.png /usr/share/httpd/noindex/common/images/pb-centos.png
+Alias /.noindex.html /usr/share/httpd/noindex/index.html
+Alias /poweredby.png /usr/share/httpd/icons/apache_pb2.png
 <% else -%>
 Alias /.noindex.html /usr/share/httpd/noindex/index.html
 Alias /noindex/css/bootstrap.min.css /usr/share/httpd/noindex/css/bootstrap.min.css


### PR DESCRIPTION
There was apparently a change in CentOS 8.4 which changed this. This matches what upstream has in their configuration.

Signed-off-by: Lance Albertson <lance@osuosl.org>
