### PR TITLE
Allow install resource to override security & charset conf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           - 'pkg-name'
           - 'ports'
           - 'ssl'
+          - 'install-override'
         exclude:
           - os: debian-9
             suite: pkg-name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- Add `default_charset`, `server_signature`, `server_tokens`, and `trace_enable` to `install` resource
+- Add `install_override` test suite
+
 ## 8.12.0 - *2021-07-08*
 
 - Add `variables` property to `default_site` resource

--- a/documentation/resource_apache2_install.md
+++ b/documentation/resource_apache2_install.md
@@ -4,30 +4,35 @@ Installs apache2.
 
 ## Properties
 
-| Name                        | Type            | Default                             | Description                                                                                                    | Allowed Values |
-| --------------------------- | --------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------- |
-| root_group                  | String          | `node['root_group']`                | Group that the root user on the box runs as. Defaults to platform specific value from ohai root_group          |
-| apache_user                 | String          | `default_apache_user`               | Set to override the default apache2 user. Defaults to platform specific locations, see libraries/helpers.rb    |
-| apache_group                | String          | `default_apache_group`              | Set to override the default apache2 user. Defaults to platform specific locations, see libraries/helpers.rb    |
-| log_dir                     | String          | `default_log_dir`                   | Log directory location. Defaults to platform specific locations, see libraries/helpers.rb                      |
-| error_log                   | String          | `default_error_log`                 | Error log location. Defaults to platform specific locations, see libraries/helpers.rb                          |
-| mpm                         | String          | `default_mpm`                       | Multi-processing Module. Defaults to platform specific locations, see libraries/helpers.rb                     |
-| mpm_conf                    | Hash            | `{}`                                | Configuration parameters for the MPM.                                                                          |
-| modules                     | [String, Array] | `default_modules`                   | Defaults modules, defaults to platform specific values, see libraries/helpers.rb                               |
-| mod_conf                    | Hash            | `{}`                                | Configuration parameters for the defaults modules, as an Hash of Hash.                                         |
-| docroot_dir                 | String          | `default_docroot_dir`               | Apache document root. Defaults to platform specific locations, see libraries/helpers.rb                        |
-| run_dir                     | String          | `default_run_dir`                   | Location for APACHE_RUN_DIR. Defaults to platform specific locations, see libraries/helpers.rb                 |
-| log_level                   | String          | `warn`                              | log level for apache2                                                                                          |
-| apache_locale               | String          | `system`                            | Locale for apache2, defaults to the system locale                                                              |
-| status_url                  | String          | `http://localhost:80/server-status` | URL for status checks                                                                                          |
-| httpd_t_timeout             | Integer         | `10`                                | Service timeout setting in seconds. Defaults to 10 seconds                                                     |
-| listen                      | [String, Array] | `[80, 443]`                         | Port to listen on. Defaults to both 80 & 443                                                                   |
-| keep_alive                  | String          | `On`                                | description: 'Persistent connection feature of HTTP/1.1 provide long-lived HTTP sessions'                      | `[On, Off]`    |
-| max_keep_alive_requests     | Integer         | `100`                               | MaxKeepAliveRequests                                                                                           |
-| keep_alive_timeout          | Integer         | `5`                                 | KeepAliveTimeout                                                                                               |
-| access_file_name            | String          | `.htaccess`                         | Access filename                                                                                                |
-| sysconfig_additional_params | Hash            | `{}`                                | Hash of additional sysconfig parameters to apply to the system                                                 |
-| template_cookbook           | String          | `apache2`                           | Cookbook to source the apache2.conf template from                                                              |
+| Name                        | Type            | Default                             | Description                                                                                                 | Allowed Values                                              |
+|-----------------------------|-----------------|-------------------------------------|-------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| root_group                  | String          | `node['root_group']`                | Group that the root user on the box runs as. Defaults to platform specific value from ohai root_group       |                                                             |
+| apache_user                 | String          | `default_apache_user`               | Set to override the default apache2 user. Defaults to platform specific locations, see libraries/helpers.rb |                                                             |
+| apache_group                | String          | `default_apache_group`              | Set to override the default apache2 user. Defaults to platform specific locations, see libraries/helpers.rb |                                                             |
+| log_dir                     | String          | `default_log_dir`                   | Log directory location. Defaults to platform specific locations, see libraries/helpers.rb                   |                                                             |
+| error_log                   | String          | `default_error_log`                 | Error log location. Defaults to platform specific locations, see libraries/helpers.rb                       |                                                             |
+| mpm                         | String          | `default_mpm`                       | Multi-processing Module. Defaults to platform specific locations, see libraries/helpers.rb                  |                                                             |
+| mpm_conf                    | Hash            | `{}`                                | Configuration parameters for the MPM.                                                                       |                                                             |
+| modules                     | [String, Array] | `default_modules`                   | Defaults modules, defaults to platform specific values, see libraries/helpers.rb                            |                                                             |
+| mod_conf                    | Hash            | `{}`                                | Configuration parameters for the defaults modules, as an Hash of Hash.                                      |                                                             |
+| docroot_dir                 | String          | `default_docroot_dir`               | Apache document root. Defaults to platform specific locations, see libraries/helpers.rb                     |                                                             |
+| run_dir                     | String          | `default_run_dir`                   | Location for APACHE_RUN_DIR. Defaults to platform specific locations, see libraries/helpers.rb              |                                                             |
+| log_level                   | String          | `warn`                              | log level for apache2                                                                                       |                                                             |
+| apache_locale               | String          | `system`                            | Locale for apache2, defaults to the system locale                                                           |                                                             |
+| status_url                  | String          | `http://localhost:80/server-status` | URL for status checks                                                                                       |                                                             |
+| server_name                 | String          | `localhost`                         | ServerName value, set in _apache2.conf_ at the server level                                                 |                                                             |
+| server_signature            | String          | `On`                                | ServerSignature value, set in _security.conf_                                                               | `[On, Off, EMail]`                                          |
+| server_tokens               | String          | `Prod`                              | ServerTokens value, set in _security.conf_                                                                  | `[Major, Minor, Min, Minimal, Prod, ProductOnly, OS, Full]` |
+| trace_enable                | String          | `Off`                               | TraceEnable value, set in _security.conf_                                                                   | `[On, Off, extended]`                                       |
+| default_charset             | [String, Array] |                                     | AddDefaultCharset value(s), set in _charset.conf_                                                           |                                                             |
+| httpd_t_timeout             | Integer         | `10`                                | Service timeout setting in seconds. Defaults to 10 seconds                                                  |                                                             |
+| listen                      | [String, Array] | `[80, 443]`                         | Port to listen on. Defaults to both 80 & 443                                                                |                                                             |
+| keep_alive                  | String          | `On`                                | description: 'Persistent connection feature of HTTP/1.1 provide long-lived HTTP sessions'                   | `[On, Off]`                                                 |
+| max_keep_alive_requests     | Integer         | `100`                               | MaxKeepAliveRequests                                                                                        |                                                             |
+| keep_alive_timeout          | Integer         | `5`                                 | KeepAliveTimeout                                                                                            |                                                             |
+| access_file_name            | String          | `.htaccess`                         | Access filename                                                                                             |                                                             |
+| sysconfig_additional_params | Hash            | `{}`                                | Hash of additional sysconfig parameters to apply to the system                                              |                                                             |
+| template_cookbook           | String          | `apache2`                           | Cookbook to source the apache2.conf template from                                                           |                                                             |
 
 ## Examples
 
@@ -62,5 +67,16 @@ apache2_install 'default' do
     }
   )
   modules lazy { default_modules.delete_if { |x| x=='autoindex' } }
+end
+```
+
+```ruby
+apache2_install 'overrides' do
+  # override the values in _security.conf_
+  server_signature 'EMail'
+  server_tokens 'Full'
+  trace_enable 'On'
+  # override the values in _charset.conf_
+  default_charset 'utf-8'
 end
 ```

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -55,3 +55,6 @@ suites:
   - name: mod_auth_cas
     run_list:
       - recipe[test::auth_cas]
+  - name: install_override
+    run_list:
+      - recipe[test::install_override]

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -51,6 +51,25 @@ property :server_name, String,
          default: 'localhost',
          description: 'Sets the ServerName directive'
 
+property :server_signature, String,
+         equal_to: %w(On Off EMail),
+         default: 'On',
+         description: 'Sets the ServerSignature directive'
+
+property :server_tokens, String,
+         equal_to: %w(Major Minor Min Minimal Prod ProductOnly OS Full),
+         default: 'Prod',
+         description: 'Sets the ServerTokens directive'
+
+property :trace_enable, String,
+         equal_to: %w(On Off extended),
+         default: 'Off',
+         description: 'Sets the TraceEnable directive'
+
+property :default_charset, [String, Array],
+         coerce: proc { |p| p.is_a?(Array) ? p : Array(p) },
+         description: 'Sets the AddDefaultCharset directive for each element provided'
+
 property :httpd_t_timeout, Integer,
          default: 10,
          description: 'Service timeout setting. Defaults to 10 seconds'
@@ -286,8 +305,19 @@ action :install do
     template_cookbook new_resource.template_cookbook
   end
 
-  apache2_conf 'security'
-  apache2_conf 'charset'
+  apache2_conf 'security' do
+    options(
+      server_signature: new_resource.server_signature,
+      server_tokens: new_resource.server_tokens,
+      trace_enable: new_resource.trace_enable
+    )
+  end
+
+  apache2_conf 'charset' do
+    options(
+      default_charset: new_resource.default_charset
+    )
+  end
 
   template 'ports.conf' do
     path     "#{apache_dir}/ports.conf"

--- a/templates/apache2.conf.erb
+++ b/templates/apache2.conf.erb
@@ -5,6 +5,13 @@
 ServerRoot "<%= @apache_dir %>"
 
 #
+# Hostname and port that the server uses to identify itself
+#
+<% unless @server_name.nil? %>
+ServerName <%= @server_name %>
+<% end %>
+
+#
 # The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
 #
 Mutex file:<%= @lock_dir %> default

--- a/templates/security.conf.erb
+++ b/templates/security.conf.erb
@@ -9,7 +9,9 @@
 # Set to one of:  Full | OS | Minimal | Minor | Major | Prod
 # where Full conveys the most information, and Prod the least.
 #
+<% unless @server_tokens.nil? %>
 ServerTokens <%= @server_tokens %>
+<% end %>
 
 #
 # Optionally add a line containing the server version and virtual host
@@ -19,7 +21,9 @@ ServerTokens <%= @server_tokens %>
 # Set to "EMail" to also include a mailto: link to the ServerAdmin.
 # Set to one of:  On | Off | EMail
 #
+<% unless @server_signature.nil? %>
 ServerSignature <%= @server_signature %>
+<% end %>
 
 #
 # Allow TRACE method
@@ -29,4 +33,6 @@ ServerSignature <%= @server_signature %>
 #
 # Set to one of:  On | Off | extended
 #
+<% unless @trace_enable.nil? %>
 TraceEnable <%= @trace_enable %>
+<% end %>

--- a/test/cookbooks/test/recipes/install_override.rb
+++ b/test/cookbooks/test/recipes/install_override.rb
@@ -1,8 +1,8 @@
 apt_update 'update'
 
 apache2_install 'default_install' do
-  server_signature 'Off'
-  server_tokens 'Full'
+  server_signature 'On'
+  server_tokens 'Minimal'
   trace_enable 'On'
   default_charset 'utf-8'
 end

--- a/test/cookbooks/test/recipes/install_override.rb
+++ b/test/cookbooks/test/recipes/install_override.rb
@@ -1,0 +1,22 @@
+apt_update 'update'
+
+apache2_install 'default_install' do
+  server_signature 'Off'
+  server_tokens 'Full'
+  trace_enable 'On'
+  default_charset 'utf-8'
+end
+
+apache2_site '000-default' do
+  action :disable
+end
+
+apache2_default_site '' do
+  action :enable
+end
+
+service 'apache2' do
+  service_name lazy { apache_platform_service_name }
+  supports restart: true, status: true, reload: true
+  action :nothing
+end

--- a/test/cookbooks/test/templates/apache2.conf.erb
+++ b/test/cookbooks/test/templates/apache2.conf.erb
@@ -6,6 +6,13 @@
 ServerRoot "<%= @apache_dir %>"
 
 #
+# Hostname and port that the server uses to identify itself
+#
+<% unless @server_name.nil? %>
+ServerName <%= @server_name %>
+<% end %>
+
+#
 # The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
 #
 Mutex file:<%= @lock_dir %> default

--- a/test/integration/install_override/controls/default_spec.rb
+++ b/test/integration/install_override/controls/default_spec.rb
@@ -1,0 +1,86 @@
+control 'service' do
+  impact 1
+  desc 'Apache2 service is running'
+
+  case os[:family]
+  when 'debian', 'suse'
+    describe service('apache2') do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+  when 'freebsd'
+    describe service('apache24') do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+  else
+    describe service('httpd') do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+  end
+end
+
+control 'welcome-page' do
+  impact 1
+  desc 'Apache2 Welcome Pages Displayed'
+
+  case os[:family]
+  when 'debian'
+    describe http('localhost') do
+      its('status') { should eq 200 }
+      its('body') { should cmp /This is the default welcome page/ }
+    end
+  when 'freebsd'
+    describe http('localhost') do
+      its('status') { should eq 200 }
+      its('body') { should_not cmp /Forbidden/ }
+    end
+  when 'suse'
+    describe http('localhost') do
+      its('status') { should eq 403 }
+      its('body') { should cmp /Forbidden/ }
+      its('body') { should cmp /Apache Server/ }
+    end
+  else
+    describe http('localhost') do
+      its('status') { should eq 403 }
+      its('body') { should_not cmp /Forbidden/ }
+      its('body') { should cmp /powered by CentOS/ }
+    end
+  end
+end
+
+control 'install-override' do
+  impact 1
+  desc 'Apache2 override install settings'
+
+  apache_dir = case os[:family]
+               when 'debian', 'suse'
+                 '/etc/apache2'
+               else
+                 '/etc/httpd'
+               end
+
+  describe file("#{apache_dir}/conf-enabled/security.conf") do
+    it { should exist }
+    its('content') { should cmp /ServerTokens Full/ }
+    its('content') { should cmp /ServerSignature Off/ }
+    its('content') { should cmp /TraceEnable On/ }
+  end
+
+  describe file("#{apache_dir}/conf-enabled/charset.conf") do
+    it { should exist }
+    its('content') { should cmp /AddDefaultCharset utf-8/ }
+  end
+end
+
+#  Disable until all platforms are pukka
+# include_controls 'dev-sec/apache-baseline' do
+#   skip_control 'apache-05' # We don't have hardening.conf
+#   skip_control 'apache-10' # We don't have hardening.conf
+#   skip_control 'apache-13' # We don't enable SSL by defauly (yet)
+# end

--- a/test/integration/install_override/controls/default_spec.rb
+++ b/test/integration/install_override/controls/default_spec.rb
@@ -43,13 +43,13 @@ control 'welcome-page' do
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should cmp /Forbidden/ }
-      its('body') { should cmp /Apache Server/ }
+      its('body') { should cmp /Apache.* Server/ }
     end
   else
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should_not cmp /Forbidden/ }
-      its('body') { should cmp /powered by CentOS/ }
+      its('body') { should cmp /powered by (the Apache|CentOS)/ }
     end
   end
 end
@@ -67,8 +67,8 @@ control 'install-override' do
 
   describe file("#{apache_dir}/conf-enabled/security.conf") do
     it { should exist }
-    its('content') { should cmp /ServerTokens Full/ }
-    its('content') { should cmp /ServerSignature Off/ }
+    its('content') { should cmp /ServerTokens Minimal/ }
+    its('content') { should cmp /ServerSignature On/ }
     its('content') { should cmp /TraceEnable On/ }
   end
 

--- a/test/integration/install_override/inspec.yml
+++ b/test/integration/install_override/inspec.yml
@@ -1,0 +1,11 @@
+---
+name: apache2-integration-tests
+title: Integration tests for apache2 cookbook
+summary: This InSpec profile contains integration tests for apache2 cookbook
+supports:
+  - os-family: linux
+  - os-family: bsd
+
+# depends:
+# - name:  dev-sec/apache-baseline
+#   supermarket: dev-sec/apache-baseline


### PR DESCRIPTION
* Add `default_charset`, `server_signature`, `server_tokens`, and
`trace_enable` to `install` resource
* Add `install_override` test suite
* Add `ServerName` directive to default `apache2.conf.erb`

# Description

Allows the `install` resource to override the values passed into the `security` and `charset` conf custom resources.

## Issues Resolved

#728 
#750 

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
