### PR TITLE
Add envvars_additional_params property to install resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- Add `envvars_additional_params` property to install resource
+
 ## 8.13.0 - *2021-07-09*
 
 - Add `default_charset`, `server_signature`, `server_tokens`, and `trace_enable` to `install` resource

--- a/documentation/resource_apache2_install.md
+++ b/documentation/resource_apache2_install.md
@@ -31,6 +31,7 @@ Installs apache2.
 | max_keep_alive_requests     | Integer         | `100`                               | MaxKeepAliveRequests                                                                                        |                                                             |
 | keep_alive_timeout          | Integer         | `5`                                 | KeepAliveTimeout                                                                                            |                                                             |
 | access_file_name            | String          | `.htaccess`                         | Access filename                                                                                             |                                                             |
+| envvars_additional_params   | Hash            | `{}`                                | Hash of additional environment variables to add to the envvars file                                         |
 | sysconfig_additional_params | Hash            | `{}`                                | Hash of additional sysconfig parameters to apply to the system                                              |                                                             |
 | template_cookbook           | String          | `apache2`                           | Cookbook to source the apache2.conf template from                                                           |                                                             |
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -128,6 +128,9 @@ property :timeout, [Integer, String],
          default: 300,
          description: 'The number of seconds before receives and sends time out'
 
+property :envvars_additional_params, Hash,
+         description: 'Hash of additional environment variables to add to the envvars file'
+
 property :sysconfig_additional_params, Hash,
          description: 'Hash of additional sysconfig parameters to apply to the system'
 
@@ -284,7 +287,8 @@ action :install do
       pid_file: apache_pid_file,
       apache_locale: new_resource.apache_locale,
       status_url: new_resource.status_url,
-      run_dir: new_resource.run_dir
+      run_dir: new_resource.run_dir,
+      envvars_additional_params: new_resource.envvars_additional_params
     )
     only_if { platform_family?('debian') }
   end

--- a/spec/resources/install_spec.rb
+++ b/spec/resources/install_spec.rb
@@ -82,4 +82,24 @@ describe 'apache2_install' do
         .with_content(/Use template_cookbook property in apache2_config or apache2_install to provide your own apache2.conf/)
     end
   end
+  context 'install apache2 with custom envvars' do
+    recipe do
+      apache2_install 'custom' do
+        envvars_additional_params(
+          FOO: 'bar'
+        )
+      end
+
+      service 'apache2' do
+        service_name lazy { apache_platform_service_name }
+        supports restart: true, status: true, reload: true
+        action :nothing
+      end
+    end
+
+    it 'has a custom envvar set' do
+      is_expected.to render_file('/etc/apache2/envvars')
+        .with_content(/FOO=bar/)
+    end
+  end
 end

--- a/templates/envvars.erb
+++ b/templates/envvars.erb
@@ -43,3 +43,9 @@ export LANG
 #export APACHE2_MAINTSCRIPT_DEBUG=1
 
 APACHE_STATUSURL=<%= @status_url %>
+
+<% unless @envvars_additional_params.nil? %>
+<% @envvars_additional_params.each do |k,v| %>
+<%= "#{k}=#{v}" %>
+<% end -%>
+<% end -%>

--- a/test/cookbooks/test/recipes/install_override.rb
+++ b/test/cookbooks/test/recipes/install_override.rb
@@ -5,6 +5,9 @@ apache2_install 'default_install' do
   server_tokens 'Minimal'
   trace_enable 'On'
   default_charset 'utf-8'
+  envvars_additional_params(
+    FOO: 'bar'
+  )
 end
 
 apache2_site '000-default' do

--- a/test/cookbooks/test/recipes/install_override.rb
+++ b/test/cookbooks/test/recipes/install_override.rb
@@ -7,7 +7,10 @@ apache2_install 'default_install' do
   default_charset 'utf-8'
   envvars_additional_params(
     FOO: 'bar'
-  )
+  ) if platform_family?('debian')
+  sysconfig_additional_params(
+    FOO: 'bar'
+  ) if platform_family?('rhel', 'amazon', 'fedora', 'suse')
 end
 
 apache2_site '000-default' do

--- a/test/integration/install_override/controls/default_spec.rb
+++ b/test/integration/install_override/controls/default_spec.rb
@@ -76,6 +76,11 @@ control 'install-override' do
     it { should exist }
     its('content') { should cmp /AddDefaultCharset utf-8/ }
   end
+
+  describe file("#{apache_dir}/envvars") do
+    it { should exist }
+    its('content') { should cmp /FOO=bar/ }
+  end
 end
 
 #  Disable until all platforms are pukka

--- a/test/integration/install_override/controls/default_spec.rb
+++ b/test/integration/install_override/controls/default_spec.rb
@@ -65,6 +65,13 @@ control 'install-override' do
                  '/etc/httpd'
                end
 
+  apache_platform_service_name = case os[:family]
+                                 when 'debian', 'suse'
+                                   'apache2'
+                                 else
+                                   'httpd'
+                                 end
+
   describe file("#{apache_dir}/conf-enabled/security.conf") do
     it { should exist }
     its('content') { should cmp /ServerTokens Minimal/ }
@@ -77,9 +84,17 @@ control 'install-override' do
     its('content') { should cmp /AddDefaultCharset utf-8/ }
   end
 
-  describe file("#{apache_dir}/envvars") do
-    it { should exist }
-    its('content') { should cmp /FOO=bar/ }
+  case os[:family]
+  when 'debian'
+    describe file("#{apache_dir}/envvars") do
+      it { should exist }
+      its('content') { should cmp /FOO=bar/ }
+    end
+  when 'redhat', 'suse'
+    describe file("/etc/sysconfig/#{apache_platform_service_name}") do
+      it { should exist }
+      its('content') { should cmp /FOO=bar/ }
+    end
   end
 end
 


### PR DESCRIPTION
This allows custom environment variables to be added to the envvars file

Signed-off-by: Hans Rakers <hans@shoq.com>

# Description

This PR revives work submitted earlier in #451 that never got merged. This change allows custom environment variables to be added to the envvars file (For example: override file descriptor limit, set ORACLE_HOME, etc.)

I didn't add tests since `sysconfig_additional_params` has no tests either.

## Issues Resolved

#451 

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
