### PR TITLE
Update tested platforms + remove Delivery

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,9 +1,0 @@
-[local_phases]
-unit = "rspec spec/"
-lint = 'cookstyle --display-cop-names --extra-details'
-syntax = "echo skipping"
-provision = "echo skipping"
-deploy = "echo skipping"
-smoke = "echo skipping"
-functional = "echo skipping"
-cleanup = "echo skipping"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
             suite: pkg-name
           - os: fedora-latest
             suite: pkg-name
+          - os: fedora-latest
+            suite: mod-php
           - os: ubuntu-1804
             suite: pkg-name
           - os: ubuntu-2004

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,66 +8,53 @@ name: ci
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
-          - 'centos-7'
-          - 'centos-8'
-          - 'centos-stream-8'
-          - 'debian-9'
-          - 'debian-10'
-          - 'opensuse-leap-15'
-          - 'ubuntu-1804'
+          - almalinux-8
+          - amazonlinux-2
+          - centos-7
+          - centos-stream-8
+          - debian-10
+          - debian-11
+          - fedora-latest
+          - opensuse-leap-15
+          - rockylinux-8
+          - ubuntu-1804
+          - ubuntu-2004
         suite:
-          - 'basic-site'
-          - 'default'
-          - 'mod-auth-cas'
-          - 'mod-php'
-          - 'module-template'
-          - 'mod-wsgi'
-          - 'pkg-name'
-          - 'ports'
-          - 'ssl'
-          - 'install-override'
+          - basic-site
+          - default
+          - mod-auth-cas
+          - mod-php
+          - module-template
+          - mod-wsgi
+          - pkg-name
+          - ports
+          - ssl
+          - install-override
         exclude:
-          - os: debian-9
-            suite: pkg-name
           - os: debian-10
             suite: pkg-name
-          - os: centos-8
+          - os: debian-11
+            suite: pkg-name
+          - os: almalinux-8
             suite: pkg-name
           - os: centos-stream-8
             suite: pkg-name
+          - os: rockylinux-8
+            suite: pkg-name
+          - os: fedora-latest
+            suite: pkg-name
           - os: ubuntu-1804
+            suite: pkg-name
+          - os: ubuntu-2004
             suite: pkg-name
           - os: opensuse-leap-15
             suite: pkg-name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           - ssl
           - install-override
         exclude:
+          - os: amazonlinux-2
+            suite: pkg-name
           - os: debian-10
             suite: pkg-name
           - os: debian-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- Remove delivery and switch to using reusable CI workflow
+- Update tested platforms
+  - removed: CentOS 8, Debian 9
+  - added: Rocky / Alma 8, Debian 11
+
 ## 8.14.1 - *2021-11-03*
 
 - Add CentOS Stream 8 to CI pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 - Fix mod_php on Debian 11
 - Fedora fixes
   - mod-auth-cas
+  - mod-wsgi
   - Drop support for mod_php
 
 ## 8.14.1 - *2021-11-03*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 - Update tested platforms
   - removed: CentOS 8, Debian 9
   - added: Rocky / Alma 8, Debian 11
+- Fix mod_php on Debian 11
 
 ## 8.14.1 - *2021-11-03*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This file is used to list changes made in each version of the apache2 cookbook.
   - removed: CentOS 8, Debian 9
   - added: Rocky / Alma 8, Debian 11
 - Fix mod_php on Debian 11
+- Fedora fixes
+  - mod-auth-cas
 
 ## 8.14.1 - *2021-11-03*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is used to list changes made in each version of the apache2 cookbook.
 - Fix mod_php on Debian 11
 - Fedora fixes
   - mod-auth-cas
+  - Drop support for mod_php
 
 ## 8.14.1 - *2021-11-03*
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ On ArchLinux, if you are using the `apache2::mod_auth_openid` recipe, you also n
 The following platforms and versions are tested and supported using [test-kitchen](http://kitchen.ci/)
 
 - Ubuntu 18.04 / 20.04
-- Debian 9/10
-- CentOS 7+
-- Fedora Latest
+- Debian 10 / 11
+- CentOS 7+ (incl. Rocky & Alma)
+- Fedora latest
 - OpenSUSE Leap
 
 ### Notes for RHEL Family

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,45 +1,39 @@
----
 driver:
   name: dokken
-  # because Docker and SystemD
-  privileged: true
+  privileged: true  # because Docker and SystemD
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
-  env: [CHEF_LICENSE=accept]
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
+  chef_license: accept-no-persist
 
 platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: debian-10
     driver:
       image: dokken/debian-10
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
 
   - name: centos-7
     driver:
       image: dokken/centos-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: centos-8
-    driver:
-      image: dokken/centos-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: centos-stream-8
@@ -47,21 +41,27 @@ platforms:
       image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: fedora-latest
+    driver:
+      image: dokken/fedora-latest
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15
-      pid_one_command: /bin/systemd
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
   product_name: chef
   enforce_idempotency: true
   multiple_converge: 2
@@ -13,13 +13,14 @@ verifier:
   name: inspec
 
 platforms:
+  - name: almalinux-8
   - name: amazonlinux-2
   - name: centos-7
-  - name: centos-8
   - name: centos-stream-8
-  - name: debian-9
   - name: debian-10
+  - name: debian-11
   - name: opensuse-leap-15
+  - name: rockylinux-8
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -46,6 +46,8 @@ suites:
   - name: mod_php
     run_list:
       - recipe[test::php]
+    excludes:
+      - fedora-latest
   - name: pkg_name
     run_list:
       - recipe[test::pkg_name]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   product_name: chef
   enforce_idempotency: true
   multiple_converge: 2

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -399,7 +399,7 @@ module Apache2
         case node['platform_family']
         when 'debian'
           'libapache2-mod-php'
-        when 'rhel', 'fedora', 'amazon'
+        when 'rhel', 'amazon'
           'mod_php'
         when 'suse'
           'apache2-mod_php7'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -455,7 +455,7 @@ module Apache2
           'libapache2-mod-wsgi-py3'
         when 'amazon'
           'mod_wsgi'
-        when 'rhel'
+        when 'rhel', 'fedora'
           if node['platform_version'].to_i >= 8
             'python3-mod_wsgi'
           else
@@ -467,7 +467,7 @@ module Apache2
       end
 
       def apache_mod_wsgi_filename
-        if platform_family?('rhel') && node['platform_version'].to_i >= 8
+        if platform_family?('rhel', 'fedora') && node['platform_version'].to_i >= 8
           'mod_wsgi_python3.so'
         else
           'mod_wsgi.so'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -424,8 +424,10 @@ module Apache2
       def apache_mod_php_filename
         case node['platform_family']
         when 'debian'
-          if platform?('debian') && node['platform_version'].to_i >= 10
+          if platform?('debian') && node['platform_version'].to_i == 10
             'libphp7.3.so'
+          elsif platform?('debian') && node['platform_version'].to_i >= 11
+            'libphp7.4.so'
           elsif platform?('ubuntu') && node['platform_version'].to_f == 18.04
             'libphp7.2.so'
           elsif platform?('ubuntu') && node['platform_version'].to_f >= 20.04

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -475,7 +475,8 @@ module Apache2
       end
 
       def apache_mod_auth_cas_install_method
-        if (platform_family?('rhel') && node['platform_version'].to_i >= 8) || platform_family?('suse')
+        if (platform_family?('rhel') && node['platform_version'].to_i >= 8) \
+          || platform_family?('suse') || platform_family?('fedora')
           'source'
         else
           'package'
@@ -483,7 +484,7 @@ module Apache2
       end
 
       def apache_mod_auth_cas_devel_packages
-        if platform_family?('rhel', 'amazon')
+        if platform_family?('rhel', 'amazon', 'fedora')
           %w(openssl-devel libcurl-devel pcre-devel libtool)
         elsif platform_family?('debian')
           %w(libssl-dev libcurl4-openssl-dev libpcre++-dev libtool)

--- a/resources/mod_auth_cas.rb
+++ b/resources/mod_auth_cas.rb
@@ -85,7 +85,7 @@ action :install do
     when 'rhel', 'fedora', 'amazon'
       include_recipe 'yum-epel' unless platform_family?('fedora')
 
-      yum_package 'mod_auth_cas' do
+      package 'mod_auth_cas' do
         notifies :run, 'execute[generate-module-list]', :immediately
         notifies :delete, 'directory[purge distro conf.modules.d]', :immediately
         notifies :delete, 'directory[purge distro conf.d]', :immediately

--- a/test/integration/custom_template/controls/default_spec.rb
+++ b/test/integration/custom_template/controls/default_spec.rb
@@ -49,7 +49,7 @@ control 'welcome-page' do
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should_not cmp /Forbidden/ }
-      its('body') { should cmp /powered by CentOS/ }
+      its('body') { should cmp /Powered by (CentOS|Alma|Rocky)/ }
     end
   end
 end
@@ -100,7 +100,7 @@ control 'custom-conf' do
       its('content') { should include 'IndexOptions Charset=UTF-8' }
     end
   else
-    describe file('/etc/httpd/conf/conf-enabled/custom.conf') do
+    describe file('/etc/httpd/conf-enabled/custom.conf') do
       it { should exist }
       its('content') { should include 'IndexIgnore . .secret *.gen' }
       its('content') { should include 'IndexOptions Charset=UTF-8' }

--- a/test/integration/custom_template/controls/default_spec.rb
+++ b/test/integration/custom_template/controls/default_spec.rb
@@ -49,7 +49,7 @@ control 'welcome-page' do
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should_not cmp /Forbidden/ }
-      its('body') { should cmp /Powered by (CentOS|Alma|Rocky)/ }
+      its('body') { should cmp /Powered by (CentOS|Alma|Rocky|Fedora|Apache)/ }
     end
   end
 end

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -49,7 +49,7 @@ control 'welcome-page' do
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should_not cmp /Forbidden/ }
-      its('body') { should cmp /Powered by (CentOS|Alma|Rocky|Apache)/ }
+      its('body') { should cmp /Powered by (CentOS|Alma|Rocky|Fedora|Apache)/ }
     end
   end
 end

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -49,7 +49,7 @@ control 'welcome-page' do
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should_not cmp /Forbidden/ }
-      its('body') { should cmp /powered by CentOS/ }
+      its('body') { should cmp /Powered by (CentOS|Alma|Rocky)/ }
     end
   end
 end

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -49,7 +49,7 @@ control 'welcome-page' do
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should_not cmp /Forbidden/ }
-      its('body') { should cmp /Powered by (CentOS|Alma|Rocky)/ }
+      its('body') { should cmp /Powered by (CentOS|Alma|Rocky|Apache)/ }
     end
   end
 end

--- a/test/integration/install_override/controls/default_spec.rb
+++ b/test/integration/install_override/controls/default_spec.rb
@@ -49,7 +49,7 @@ control 'welcome-page' do
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should_not cmp /Forbidden/ }
-      its('body') { should cmp /Powered by (the Apache|CentOS|Alma|Rocky)/ }
+      its('body') { should cmp /Powered by (CentOS|Alma|Rocky|Fedora|Apache)/ }
     end
   end
 end

--- a/test/integration/install_override/controls/default_spec.rb
+++ b/test/integration/install_override/controls/default_spec.rb
@@ -49,7 +49,7 @@ control 'welcome-page' do
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should_not cmp /Forbidden/ }
-      its('body') { should cmp /powered by (the Apache|CentOS)/ }
+      its('body') { should cmp /Powered by (the Apache|CentOS|Alma|Rocky)/ }
     end
   end
 end

--- a/test/integration/mod_auth_cas/controls/default.rb
+++ b/test/integration/mod_auth_cas/controls/default.rb
@@ -2,11 +2,19 @@ include_controls 'apache2-integration-tests' do
   skip_control 'welcome-page'
 end
 
+os_family = os.family
+
 control 'auth_cas module enabled & running' do
   impact 1
   desc 'auth_cas module should be enabled with config'
 
-  describe command('apachectl -M') do
-    its('stdout') { should match(/auth_cas/) }
+  if os_family == 'fedora'
+    describe command('httpd -M') do
+      its('stdout') { should match(/auth_cas/) }
+    end
+  else
+    describe command('apachectl -M') do
+      its('stdout') { should match(/auth_cas/) }
+    end
   end
 end

--- a/test/integration/mod_wsgi/controls/default.rb
+++ b/test/integration/mod_wsgi/controls/default.rb
@@ -2,12 +2,20 @@ include_controls 'apache2-integration-tests' do
   skip_control 'welcome-page'
 end
 
+os_family = os.family
+
 control 'WSGI module enabled & running' do
   impact 1
   desc 'wsgi module should be enabled with config'
 
-  describe command('apachectl -M') do
-    its('stdout') { should match(/wsgi_module/) }
+  if os_family == 'fedora'
+    describe command('httpd -M') do
+      its('stdout') { should match(/wsgi_module/) }
+    end
+  else
+    describe command('apachectl -M') do
+      its('stdout') { should match(/wsgi_module/) }
+    end
   end
 
   describe http('localhost') do


### PR DESCRIPTION
# Description

- Remove delivery and switch to using reusable CI workflow
- Update tested platforms
  - removed: CentOS 8, Debian 9
  - added: Rocky / Alma 8, Debian 11, Fedora

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
