### PR TITLE
Create apache2_service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,21 @@ jobs:
       matrix:
         os:
           - almalinux-8
-          - amazonlinux-2
+          - almalinux-9
+          - amazonlinux-2023
           - centos-7
           - centos-stream-8
+          - centos-stream-9
           - debian-10
           - debian-11
+          - debian-12
           - fedora-latest
           - opensuse-leap-15
           - rockylinux-8
+          - rockylinux-9
           - ubuntu-1804
           - ubuntu-2004
+          - ubuntu-2204
         suite:
           - basic-site
           - default
@@ -45,27 +50,50 @@ jobs:
           - ssl
           - install-override
         exclude:
-          - os: amazonlinux-2
+          - os: amazonlinux-2023
+            suite: mod-php
+          - os: almalinux-9
+            suite: mod-php
+          - os: centos-stream-9
+            suite: mod-php
+          - os: fedora-latest
+            suite: mod-php
+          - os: rockylinux-9
+            suite: mod-php
+          - os: amazonlinux-2023
+            suite: mod-wsgi
+          # TODO: disabled due to https://github.com/chef/chef/pull/13691
+          - os: opensuse-leap-15
+            suite: mod-wsgi
+          - os: almalinux-8
+            suite: pkg-name
+          - os: almalinux-9
+            suite: pkg-name
+          - os: amazonlinux-2023
+            suite: pkg-name
+          - os: centos-stream-8
+            suite: pkg-name
+          - os: centos-stream-9
             suite: pkg-name
           - os: debian-10
             suite: pkg-name
           - os: debian-11
             suite: pkg-name
-          - os: almalinux-8
+          - os: debian-12
             suite: pkg-name
-          - os: centos-stream-8
+          - os: fedora-latest
+            suite: pkg-name
+          - os: opensuse-leap-15
             suite: pkg-name
           - os: rockylinux-8
             suite: pkg-name
-          - os: fedora-latest
+          - os: rockylinux-9
             suite: pkg-name
-          - os: fedora-latest
-            suite: mod-php
           - os: ubuntu-1804
             suite: pkg-name
           - os: ubuntu-2004
             suite: pkg-name
-          - os: opensuse-leap-15
+          - os: ubuntu-2204
             suite: pkg-name
       fail-fast: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,29 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- *Breaking Change:* Create `apache2_service` resource for managing the Apache service and remove all internal
+  references to reloading `service[apache2]`.
+- Update to modern platforms
+  - *Breaking Change:* Remove Amazon Linux 2
+  - Add Amazon Linux 2023, EL9, Debian 12 and Ubuntu 22.04
+- Deprecate `apache2_mod_php` for EL9, Fedora and Amazon Linux
+- Deprecate `apache2_mod_wsgi` for Amazon Linux
+
 ## 8.15.10 - *2023-04-17*
+
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.15.9 - *2023-04-07*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
+## 8.15.9 - *2023-04-07*
+
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.15.6 - *2023-04-01*
 
-Standardise files with files in sous-chefs/repo-management
-
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.15.5 - *2023-03-02*
 
@@ -24,33 +35,35 @@ Standardise files with files in sous-chefs/repo-management
 
 ## 8.15.4 - *2023-02-28*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.15.3 - *2023-02-20*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.15.2 - *2023-02-15*
 
+- Update actions/stale action to v7
+
 ## 8.15.1 - *2023-02-14*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.15.0 - *2023-02-13*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.14.7 - *2023-02-13*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.14.6 - *2022-12-13*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.14.5 - *2022-12-08*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.14.4 - *2022-05-16*
 

--- a/README.md
+++ b/README.md
@@ -42,31 +42,29 @@ On ArchLinux, if you are using the `apache2::mod_auth_openid` recipe, you also n
 
 The following platforms and versions are tested and supported using [test-kitchen](http://kitchen.ci/)
 
-- Ubuntu 18.04 / 20.04
-- Debian 10 / 11
+- Amazon Linux 2023
 - CentOS 7+ (incl. Rocky & Alma)
+- Debian 10+
 - Fedora latest
-- OpenSUSE Leap
-
-### Notes for RHEL Family
-
-Apache2.4 support for Centos 6 is not officially supported.
+- OpenSUSE Leap 15
+- Ubuntu 18.04+
 
 ## Usage
 
 It is recommended to create a project or organization specific [wrapper cookbook](https://blog.chef.io/doing-wrapper-cookbooks-right) and add the desired custom resources to the run list of a node. Depending on your environment, you may have multiple roles that use different recipes from this cookbook. Adjust any attributes as desired.
 
 ```ruby
-# service['apache2'] is defined in the apache2_default_install resource but other resources are currently unable to reference it.  To work around this issue, define the following helper in your cookbook:
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+apache2_install 'default_install' do
+  notifies :restart, 'apache2_service[default]'
 end
 
-apache2_install 'default_install'
-apache2_module 'headers'
-apache2_module 'ssl'
+apache2_module 'headers' do
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_module 'ssl' do
+  notifies :reload, 'apache2_service[default]'
+end
 
 apache2_default_site 'foo' do
   default_site_name 'my_site'
@@ -74,25 +72,31 @@ apache2_default_site 'foo' do
   port '443'
   template_source 'my_site.conf.erb'
   action :enable
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_service 'default' do
+  action [:enable, :start]
 end
 ```
 
 Example wrapper cookbooks:
-[basic site](https://github.com/sous-chefs/apache2/blob/master/test/cookbooks/test/recipes/basic_site.rb)
-[ssl site](https://github.com/sous-chefs/apache2/blob/master/test/cookbooks/test/recipes/mod_ssl.rb)
+[basic site](test/cookbooks/test/recipes/basic_site.rb)
+[ssl site](test/cookbooks/test/recipes/mod_ssl.rb)
 
 ## Resources
 
-- [install](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_install.md)
-- [default_site](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_default_site.md)
-- [site](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_site.md)
-- [conf](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_conf.md)
-- [config](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_config.md)
-- [mod](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod.md)
-- [module](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_module.md)
-- [mod_php](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod_php.md)
-- [mod_wsgi](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod_wsgi.md)
-- [mod_auth_cas](https://github.com/sous-chefs/apache2/blob/master/documentation/resource_apache2_mod_auth_cas.md)
+- [install](documentation/resource_apache2_install.md)
+- [service](documentation/resource_apache2_service.md)
+- [default_site](documentation/resource_apache2_default_site.md)
+- [site](documentation/resource_apache2_site.md)
+- [conf](documentation/resource_apache2_conf.md)
+- [config](documentation/resource_apache2_config.md)
+- [mod](documentation/resource_apache2_mod.md)
+- [module](documentation/resource_apache2_module.md)
+- [mod_php](documentation/resource_apache2_mod_php.md)
+- [mod_wsgi](documentation/resource_apache2_mod_wsgi.md)
+- [mod_auth_cas](documentation/resource_apache2_mod_auth_cas.md)
 
 ## Contributors
 

--- a/documentation/resource_apache2_conf.md
+++ b/documentation/resource_apache2_conf.md
@@ -1,5 +1,7 @@
 # apache2_conf
 
+[Back to resource list](../README.md#resources)
+
 Writes conf files to the `conf-available` folder, and passes enabled values to `apache2_config`.
 
 ## Properties

--- a/documentation/resource_apache2_config.md
+++ b/documentation/resource_apache2_config.md
@@ -1,5 +1,7 @@
 # apache2_config
 
+[Back to resource list](../README.md#resources)
+
 ## Properties
 
 | name                    | Type            | Default                     | Description                                                                                                    |

--- a/documentation/resource_apache2_default_site.md
+++ b/documentation/resource_apache2_default_site.md
@@ -1,5 +1,7 @@
 # apache2_default_site
 
+[Back to resource list](../README.md#resources)
+
 Controls the default site.
 
 ## Properties

--- a/documentation/resource_apache2_install.md
+++ b/documentation/resource_apache2_install.md
@@ -1,5 +1,7 @@
 # apache2_install
 
+[Back to resource list](../README.md#resources)
+
 Installs apache2.
 
 ## Properties

--- a/documentation/resource_apache2_mod.md
+++ b/documentation/resource_apache2_mod.md
@@ -1,5 +1,7 @@
 # apache2_mod
 
+[Back to resource list](../README.md#resources)
+
 Sets up configuration file for an Apache module from a template. The template should be in the same cookbook where the definition is used. This is used by the `apache2_module` definition and is not often used directly.
 
 This will use a template resource to write the module's configuration file in the `mods-available` under the Apache configuration directory (`apache_dir`). This is a platform-dependent location.

--- a/documentation/resource_apache2_mod_auth_cas.md
+++ b/documentation/resource_apache2_mod_auth_cas.md
@@ -1,6 +1,6 @@
 # apache2_mod_auth_cas
 
-[back to resource list](https://github.com/sous-chefs/apache2#resources)
+[Back to resource list](../README.md#resources)
 
 Enables apache2 module `mod_auth_cas`.
 

--- a/documentation/resource_apache2_mod_php.md
+++ b/documentation/resource_apache2_mod_php.md
@@ -1,5 +1,7 @@
 # apache2_mod_php
 
+[Back to resource list](../README.md#resources)
+
 Enables apache2 module `mod_php`.
 
 This resource will install and enable the Apache PHP module. See `apache_mod_php_package` for the platform-specific module package.

--- a/documentation/resource_apache2_mod_proxy.md
+++ b/documentation/resource_apache2_mod_proxy.md
@@ -1,5 +1,7 @@
 # apache2_mod_proxy
 
+[Back to resource list](../README.md#resources)
+
 Installs apache2 module `mod_proxy`.
 
 See [mod_proxy](https://httpd.apache.org/docs/trunk/mod/mod_proxy.html) for further documentation.

--- a/documentation/resource_apache2_mod_wsgi.md
+++ b/documentation/resource_apache2_mod_wsgi.md
@@ -1,6 +1,6 @@
 # apache2_mod_wsgi
 
-[back to resource list](https://github.com/sous-chefs/apache2#resources)
+[Back to resource list](../README.md#resources)
 
 Enables apache2 module `mod_wsgi`.
 

--- a/documentation/resource_apache2_service.md
+++ b/documentation/resource_apache2_service.md
@@ -1,0 +1,43 @@
+# apache2_service
+
+[Back to resource list](../README.md#resources)
+
+## Actions
+
+- `:start`
+- `:stop`
+- `:restart`
+- `:reload`
+- `:enable`
+- `:disable`
+
+## Properties
+
+| Name           | Type        | Default                        | Description                          |
+| -------------- | ----------- | ------------------------------ | ------------------------------------ |
+| `service_name` | String      | `apache_platform_service_name` | Service name to perform actions for  |
+| `delay_start`  | True, False | `true`                         | Delay service start until end of run |
+
+## Examples
+
+```ruby
+apache2_service 'default' do
+  action [:enable, :start]
+end
+```
+
+## Example - using notifications
+
+```ruby
+apache2_install 'default' do
+  notifies :restart, 'apache2_service[default]'
+end
+
+apache2_default_site 'default' do
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_service 'default' do
+  action [:enable, :start]
+end
+```

--- a/documentation/resource_apache2_site.md
+++ b/documentation/resource_apache2_site.md
@@ -1,5 +1,7 @@
 # apache2_site
 
+[Back to resource list](../README.md#resources)
+
 Enable or disable a VirtualHost in `#{apache_dir}/sites-available` by calling a2ensite or a2dissite to manage the symbolic link in `#{apache_dir}/sites-enabled`.
 
 The template for the site must be managed as a separate resource. For an example of this see `apache2_default_site` resource.

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -14,15 +14,20 @@ verifier:
 
 platforms:
   - name: almalinux-8
-  - name: amazonlinux-2
+  - name: almalinux-9
+  - name: amazonlinux-2023
   - name: centos-7
   - name: centos-stream-8
+  - name: centos-stream-9
   - name: debian-10
   - name: debian-11
+  - name: debian-12
   - name: opensuse-leap-15
   - name: rockylinux-8
+  - name: rockylinux-9
   - name: ubuntu-18.04
   - name: ubuntu-20.04
+  - name: ubuntu-22.04
 
 suites:
   - name: default
@@ -47,7 +52,12 @@ suites:
     run_list:
       - recipe[test::php]
     excludes:
+      - almalinux-9
+      - amazonlinux-2023
+      - centos-stream-9
       - fedora-latest
+      - oraclelinux-9
+      - rockylinux-9
   - name: pkg_name
     run_list:
       - recipe[test::pkg_name]
@@ -56,6 +66,8 @@ suites:
   - name: mod_wsgi
     run_list:
       - recipe[test::wsgi]
+    excludes:
+      - amazonlinux-2023
   - name: mod_auth_cas
     run_list:
       - recipe[test::auth_cas]

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -28,12 +28,10 @@ action :enable do
     backup false
     mode '0644'
     variables new_resource.options.merge({ apache_dir: apache_dir })
-    notifies :restart, 'service[apache2]', :delayed
   end
 
   execute "a2enconf #{new_resource.name}" do
     command "/usr/sbin/a2enconf #{new_resource.name}"
-    notifies :restart, 'service[apache2]', :delayed
     not_if { conf_enabled?(new_resource) }
   end
 end
@@ -41,7 +39,6 @@ end
 action :disable do
   execute "a2disconf #{new_resource.name}" do
     command "/usr/sbin/a2disconf #{new_resource.name}"
-    notifies :reload, 'service[apache2]', :delayed
     only_if { conf_enabled?(new_resource) }
   end
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -96,8 +96,6 @@ action :create do
       timeout: new_resource.timeout,
       server_name: new_resource.server_name
     )
-    notifies :enable, 'service[apache2]', :delayed
-    notifies :restart, 'service[apache2]', :delayed
   end
 end
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -328,7 +328,6 @@ action :install do
     cookbook 'apache2'
     mode     '0644'
     variables(listen: new_resource.listen)
-    notifies :restart, 'service[apache2]', :delayed
   end
 
   # MPM Support Setup
@@ -349,7 +348,6 @@ action :install do
 
       apache2_module 'mpm_event' do
         mod_conf new_resource.mpm_conf || new_resource.mod_conf[:mpm_event]
-        apache_service_notification :restart
       end
     end
 
@@ -369,7 +367,6 @@ action :install do
 
       apache2_module 'mpm_prefork' do
         mod_conf new_resource.mpm_conf || new_resource.mod_conf[:mpm_prefork]
-        apache_service_notification :restart
       end
     end
 
@@ -389,7 +386,6 @@ action :install do
 
       apache2_module 'mpm_worker' do
         mod_conf new_resource.mpm_conf || new_resource.mod_conf[:mpm_worker]
-        apache_service_notification :restart
       end
     end
   end

--- a/resources/mod.rb
+++ b/resources/mod.rb
@@ -20,7 +20,6 @@ action :create do
     group new_resource.root_group
     mode '0644'
     variables(apache_dir: apache_dir)
-    notifies :reload, 'service[apache2]', :delayed
     action :create
   end
 end

--- a/resources/mod_auth_cas.rb
+++ b/resources/mod_auth_cas.rb
@@ -60,7 +60,6 @@ action :install do
 
     archive_file mod_auth_cas_tarball do
       destination "#{Chef::Config[:file_cache_path]}/mod_auth_cas"
-      notifies :run, 'execute[compile mod_auth_cas]', :immediately
     end
 
     execute 'compile mod_auth_cas' do
@@ -118,7 +117,6 @@ action :install do
       validate_url: new_resource.validate_url,
       directives: new_resource.directives
     )
-    notifies :reload, 'service[apache2]', :delayed
   end
 
   directory "#{cache_dir}/mod_auth_cas" do

--- a/resources/mod_php.rb
+++ b/resources/mod_php.rb
@@ -19,6 +19,8 @@ property :install_package, [true, false],
          description: 'Whether to install the Apache PHP module package'
 
 action :create do
+  raise "apache2_mod_php resource is not supported on #{node['platform']} #{node['platform_version']}" unless apache_mod_php_supported?
+
   # install mod_php package (if requested)
   package new_resource.package_name do
     only_if { new_resource.install_package }
@@ -43,6 +45,5 @@ action :create do
     mod_name new_resource.so_filename
     conf true
     template_cookbook 'apache2'
-    notifies :restart, 'service[apache2]'
   end
 end

--- a/resources/mod_wsgi.rb
+++ b/resources/mod_wsgi.rb
@@ -19,6 +19,8 @@ property :install_package, [true, false],
          description: 'Whether to install the Apache WSGI module package'
 
 action :create do
+  raise 'apache2_mod_wsgi resource is not supported on amazonlinux' if platform?('amazon')
+
   # install mod_wsgi package (if requested)
   package new_resource.package_name do
     only_if { new_resource.install_package }
@@ -34,6 +36,5 @@ action :create do
   apache2_module 'wsgi' do
     identifier new_resource.module_name
     mod_name new_resource.so_filename
-    notifies :restart, 'service[apache2]'
   end
 end

--- a/resources/module.rb
+++ b/resources/module.rb
@@ -53,7 +53,6 @@ action :enable do
 
   execute "a2enmod #{new_resource.name}" do
     command "/usr/sbin/a2enmod #{new_resource.name}"
-    notifies new_resource.apache_service_notification, 'service[apache2]', :delayed
     not_if { mod_enabled?(new_resource) }
   end
 end
@@ -61,7 +60,6 @@ end
 action :disable do
   execute "a2dismod #{new_resource.name}" do
     command "/usr/sbin/a2dismod #{new_resource.name}"
-    notifies new_resource.apache_service_notification, 'service[apache2]', :delayed
     only_if { mod_enabled?(new_resource) }
   end
 end

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -1,0 +1,35 @@
+unified_mode true
+
+include Apache2::Cookbook::Helpers
+
+property :service_name, String,
+          default: lazy { apache_platform_service_name },
+          description: 'Service name to perform actions for'
+
+property :delay_start, [true, false],
+          default: true,
+          description: 'Delay service start until end of run'
+
+action_class do
+  def do_service_action(resource_action)
+    if %i(start restart reload).include?(resource_action) && new_resource.delay_start
+      declare_resource(:service, 'apache2') do
+        service_name new_resource.service_name
+        supports status: true, restart: true, reload: true
+
+        delayed_action resource_action
+      end
+    else
+      declare_resource(:service, 'apache2') do
+        service_name new_resource.service_name
+        supports status: true, restart: true, reload: true
+
+        action resource_action
+      end
+    end
+  end
+end
+
+%i(start stop restart reload enable disable).each do |action_type|
+  send(:action, action_type) { do_service_action(action) }
+end

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -7,7 +7,6 @@ property :site_name, String,
 action :enable do
   execute "a2ensite #{new_resource.site_name}" do
     command "/usr/sbin/a2ensite #{new_resource.site_name}"
-    notifies :reload, 'service[apache2]', :delayed
     not_if { apache_site_enabled?(new_resource.site_name) }
     only_if { apache_site_available?(new_resource.site_name) }
   end
@@ -16,7 +15,6 @@ end
 action :disable do
   execute "a2dissite #{new_resource.site_name}" do
     command "/usr/sbin/a2dissite #{new_resource.site_name}"
-    notifies :reload, 'service[apache2]', :delayed
     only_if { apache_site_enabled?(new_resource.site_name) }
   end
 end

--- a/spec/libraries/devel_package_spec.rb
+++ b/spec/libraries/devel_package_spec.rb
@@ -17,12 +17,7 @@ describe '#apache_devel_package' do
   end
 
   context 'amazon' do
-    platform 'amazon', '2018.03'
-    it { is_expected.to write_log('httpd24-devel') }
-  end
-
-  context 'amazon-2' do
-    platform 'amazon', '2'
+    platform 'amazon'
     it { is_expected.to write_log('httpd-devel') }
   end
 

--- a/spec/libraries/mod_auth_cas_spec.rb
+++ b/spec/libraries/mod_auth_cas_spec.rb
@@ -14,34 +14,40 @@ RSpec.describe Apache2::Cookbook::Helpers do
       allow(subject).to receive(:[]).with('platform_version').and_return(platform_version)
     end
 
+    context 'redhat 9' do
+      let(:platform_family) { 'rhel' }
+      let(:platform_version) { '9' }
+      it { expect(subject.apache_mod_auth_cas_install_method).to eq 'source' }
+    end
+
     context 'redhat 8' do
       let(:platform_family) { 'rhel' }
-      let(:platform_version) { '8.2.2004' }
+      let(:platform_version) { '8' }
       it { expect(subject.apache_mod_auth_cas_install_method).to eq 'source' }
     end
 
     context 'redhat 7' do
       let(:platform_family) { 'rhel' }
-      let(:platform_version) { '7.7.1908' }
+      let(:platform_version) { '7' }
       it { expect(subject.apache_mod_auth_cas_install_method).to eq 'package' }
     end
 
     context 'debian' do
       let(:platform_family) { 'debian' }
-      let(:platform_version) { '10' }
+      let(:platform_version) { '11' }
       it { expect(subject.apache_mod_auth_cas_install_method).to eq 'package' }
     end
 
     context 'ubuntu' do
       let(:platform_family) { 'debian' }
-      let(:platform_version) { '20.04' }
+      let(:platform_version) { '22.04' }
       it { expect(subject.apache_mod_auth_cas_install_method).to eq 'package' }
     end
 
     context 'amazonlinux' do
       let(:platform_family) { 'amazon' }
-      let(:platform_version) { '2018.03' }
-      it { expect(subject.apache_mod_auth_cas_install_method).to eq 'package' }
+      let(:platform_version) { '2023' }
+      it { expect(subject.apache_mod_auth_cas_install_method).to eq 'source' }
     end
 
     context 'suse' do
@@ -60,31 +66,31 @@ RSpec.describe Apache2::Cookbook::Helpers do
 
     context 'redhat 8' do
       let(:platform_family) { 'rhel' }
-      let(:platform_version) { '8.2.2004' }
+      let(:platform_version) { '8' }
       it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(openssl-devel libcurl-devel pcre-devel libtool) }
     end
 
     context 'redhat 7' do
       let(:platform_family) { 'rhel' }
-      let(:platform_version) { '7.7.1908' }
+      let(:platform_version) { '7' }
       it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(openssl-devel libcurl-devel pcre-devel libtool) }
     end
 
     context 'debian' do
       let(:platform_family) { 'debian' }
-      let(:platform_version) { '10' }
+      let(:platform_version) { '11' }
       it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(libssl-dev libcurl4-openssl-dev libpcre++-dev libtool) }
     end
 
     context 'ubuntu' do
       let(:platform_family) { 'debian' }
-      let(:platform_version) { '20.04' }
+      let(:platform_version) { '22.04' }
       it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(libssl-dev libcurl4-openssl-dev libpcre++-dev libtool) }
     end
 
     context 'amazonlinux' do
       let(:platform_family) { 'amazon' }
-      let(:platform_version) { '2018.03' }
+      let(:platform_version) { '2023' }
       it { expect(subject.apache_mod_auth_cas_devel_packages).to eq %w(openssl-devel libcurl-devel pcre-devel libtool) }
     end
 

--- a/spec/libraries/mod_wsgi_spec.rb
+++ b/spec/libraries/mod_wsgi_spec.rb
@@ -16,32 +16,32 @@ RSpec.describe Apache2::Cookbook::Helpers do
 
     context 'redhat 8' do
       let(:platform_family) { 'rhel' }
-      let(:platform_version) { '8.2.2004' }
+      let(:platform_version) { '8' }
       it { expect(subject.apache_mod_wsgi_package).to eq 'python3-mod_wsgi' }
     end
 
     context 'redhat 7' do
       let(:platform_family) { 'rhel' }
-      let(:platform_version) { '7.7.1908' }
+      let(:platform_version) { '7' }
       it { expect(subject.apache_mod_wsgi_package).to eq 'mod_wsgi' }
     end
 
     context 'debian' do
       let(:platform_family) { 'debian' }
-      let(:platform_version) { '10' }
+      let(:platform_version) { '11' }
       it { expect(subject.apache_mod_wsgi_package).to eq 'libapache2-mod-wsgi-py3' }
     end
 
     context 'ubuntu' do
       let(:platform_family) { 'debian' }
-      let(:platform_version) { '20.04' }
+      let(:platform_version) { '22.04' }
       it { expect(subject.apache_mod_wsgi_package).to eq 'libapache2-mod-wsgi-py3' }
     end
 
     context 'amazonlinux' do
       let(:platform_family) { 'amazon' }
-      let(:platform_version) { '2018.03' }
-      it { expect(subject.apache_mod_wsgi_package).to eq 'mod_wsgi' }
+      let(:platform_version) { '2023' }
+      it { expect(subject.apache_mod_wsgi_package).to eq nil }
     end
 
     context 'suse' do

--- a/test/cookbooks/test/recipes/auth_cas.rb
+++ b/test/cookbooks/test/recipes/auth_cas.rb
@@ -1,15 +1,15 @@
 apache2_install 'default' do
   mpm 'prefork'
-end
-
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+  notifies :restart, 'apache2_service[default]'
 end
 
 apache2_mod_auth_cas 'default' do
   directives(
     'CASCookiePath' => "#{cache_dir}/mod_auth_cas/"
   )
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_service 'default' do
+  action %i(enable start)
 end

--- a/test/cookbooks/test/recipes/basic_site.rb
+++ b/test/cookbooks/test/recipes/basic_site.rb
@@ -1,19 +1,14 @@
-apache2_install 'default'
-
-# service 'apache2' do
-#   service_name lazy { apache_platform_service_name }
-#   supports restart: true, status: true, reload: true
-#   action [:start, :enable]
-# end
-
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+apache2_install 'default' do
+  notifies :restart, 'apache2_service[default]'
 end
 
-apache2_module 'deflate'
-apache2_module 'headers'
+apache2_module 'deflate' do
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_module 'headers' do
+  notifies :reload, 'apache2_service[default]'
+end
 
 app_dir = '/var/www/basic_site'
 
@@ -39,6 +34,7 @@ apache2_default_site 'basic_site' do
     log_dir: lazy { default_log_dir },
     site_name: 'basic_site'
   )
+  notifies :reload, 'apache2_service[default]'
 end
 
 apache2_default_site 'disabled_site' do
@@ -51,8 +47,14 @@ apache2_default_site 'disabled_site' do
     document_root: app_dir,
     log_dir: lazy { default_log_dir }
   )
+  notifies :reload, 'apache2_service[default]'
 end
 
 apache2_site '000-default' do
   action :disable
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_service 'default' do
+  action %i(enable start)
 end

--- a/test/cookbooks/test/recipes/custom_template.rb
+++ b/test/cookbooks/test/recipes/custom_template.rb
@@ -2,20 +2,17 @@ apt_update 'update'
 
 apache2_install 'default_install' do
   template_cookbook 'test'
-end
-
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+  notifies :restart, 'apache2_service[default]'
 end
 
 apache2_site '000-default' do
   action :disable
+  notifies :reload, 'apache2_service[default]'
 end
 
 apache2_default_site '' do
   action :enable
+  notifies :reload, 'apache2_service[default]'
 end
 
 apache2_conf 'custom' do
@@ -24,7 +21,9 @@ apache2_conf 'custom' do
     index_ignore: '. .secret *.gen',
     index_charset: 'UTF-8'
   )
+  notifies :reload, 'apache2_service[default]'
 end
 
-# /etc/apache2/conf-enabled/custom.conf
-# /etc/httpd/conf-available/custom.conf
+apache2_service 'default' do
+  action %i(enable start)
+end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,17 +1,19 @@
 apt_update 'update'
 
-apache2_install 'default_install'
+apache2_install 'default_install' do
+  notifies :restart, 'apache2_service[default]'
+end
 
 apache2_site '000-default' do
   action :disable
+  notifies :reload, 'apache2_service[default]'
 end
 
 apache2_default_site '' do
   action :enable
+  notifies :reload, 'apache2_service[default]'
 end
 
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+apache2_service 'default' do
+  action %i(enable start)
 end

--- a/test/cookbooks/test/recipes/install_override.rb
+++ b/test/cookbooks/test/recipes/install_override.rb
@@ -11,18 +11,19 @@ apache2_install 'default_install' do
   sysconfig_additional_params(
     FOO: 'bar'
   ) if platform_family?('rhel', 'amazon', 'fedora', 'suse')
+  notifies :restart, 'apache2_service[default]'
 end
 
 apache2_site '000-default' do
   action :disable
+  notifies :reload, 'apache2_service[default]'
 end
 
 apache2_default_site '' do
   action :enable
+  notifies :reload, 'apache2_service[default]'
 end
 
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+apache2_service 'default' do
+  action %i(enable start)
 end

--- a/test/cookbooks/test/recipes/mod_ssl.rb
+++ b/test/cookbooks/test/recipes/mod_ssl.rb
@@ -2,19 +2,25 @@ ssl_cert_file     = "#{apache_dir}/ssl/server.crt"
 ssl_cert_key_file = "#{apache_dir}/ssl/server.key"
 app_dir           = '/var/www/basic_site'
 
-apache2_install 'default'
-
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+apache2_install 'default' do
+  notifies :restart, 'apache2_service[default]'
 end
 
-apache2_module 'deflate'
-apache2_module 'headers'
-apache2_module 'ssl'
+apache2_module 'deflate' do
+  notifies :reload, 'apache2_service[default]'
+end
 
-apache2_mod_ssl ''
+apache2_module 'headers' do
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_module 'ssl' do
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_mod_ssl '' do
+  notifies :reload, 'apache2_service[default]'
+end
 
 directory app_dir do
   owner     lazy { default_apache_user }
@@ -60,6 +66,13 @@ apache2_default_site site_name do
     ssl_cert_file: ssl_cert_file,
     ssl_cert_key_file: ssl_cert_key_file
   )
+  notifies :reload, 'apache2_service[default]'
 end
 
-apache2_site site_name
+apache2_site site_name do
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_service 'default' do
+  action %i(enable start)
+end

--- a/test/cookbooks/test/recipes/module_template.rb
+++ b/test/cookbooks/test/recipes/module_template.rb
@@ -1,12 +1,13 @@
-apache2_install 'default'
-
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+apache2_install 'default' do
+  notifies :restart, 'apache2_service[default]'
 end
 
 apache2_module 'info' do
   conf true
   template_cookbook 'test'
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_service 'default' do
+  action %i(enable start)
 end

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -1,19 +1,22 @@
 apache2_install 'default' do
   mpm 'prefork'
+  notifies :restart, 'apache2_service[default]'
 end
 
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+apache2_mod_php '' do
+  notifies :reload, 'apache2_service[default]'
 end
-
-apache2_mod_php
 
 file "#{default_docroot_dir}/info.php" do
   content "<?php\nphpinfo();\n?>"
 end
 
-apache2_default_site 'php_test'
+apache2_default_site 'php_test' do
+  notifies :reload, 'apache2_service[default]'
+end
 
 package 'curl' if platform?('debian')
+
+apache2_service 'default' do
+  action %i(enable start)
+end

--- a/test/cookbooks/test/recipes/pkg_name.rb
+++ b/test/cookbooks/test/recipes/pkg_name.rb
@@ -2,26 +2,30 @@ include_recipe 'yum-ius'
 
 apache2_install 'default_install' do
   apache_pkg 'httpd24u'
+  notifies :restart, 'apache2_service[default]'
 end
 
 apache2_site '000-default' do
   action :disable
+  notifies :reload, 'apache2_service[default]'
 end
 
 apache2_default_site '' do
   action :enable
-end
-
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+  notifies :reload, 'apache2_service[default]'
 end
 
 apache2_module 'ssl' do
   mod_conf(
     mod_ssl_pkg: 'httpd24u-mod_ssl'
   )
+  notifies :reload, 'apache2_service[default]'
 end
 
-apache2_mod_ssl ''
+apache2_mod_ssl '' do
+  notifies :reload, 'apache2_service[default]'
+end
+
+apache2_service 'default' do
+  action %i(enable start)
+end

--- a/test/cookbooks/test/recipes/ports.rb
+++ b/test/cookbooks/test/recipes/ports.rb
@@ -2,10 +2,9 @@ apt_update 'update'
 
 apache2_install 'default_install' do
   listen '8080'
+  notifies :restart, 'apache2_service[default]'
 end
 
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true
-  action :nothing
+apache2_service 'default' do
+  action %i(enable start)
 end

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -28,6 +28,8 @@ control 'welcome-page' do
   impact 1
   desc 'Apache2 Welcome Pages Displayed'
 
+  os_name = os[:name]
+
   case os[:family]
   when 'debian'
     describe http('localhost') do
@@ -49,7 +51,11 @@ control 'welcome-page' do
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should_not cmp /Forbidden/ }
-      its('body') { should cmp /Powered by (CentOS|Alma|Rocky|Fedora|Apache)/ }
+      if os_name == 'amazon'
+        its('body') { should cmp /It works!/ }
+      else
+        its('body') { should cmp /Powered by (CentOS|Alma|Rocky|Fedora|Apache)/ }
+      end
     end
   end
 end

--- a/test/integration/install_override/controls/default_spec.rb
+++ b/test/integration/install_override/controls/default_spec.rb
@@ -28,6 +28,8 @@ control 'welcome-page' do
   impact 1
   desc 'Apache2 Welcome Pages Displayed'
 
+  os_name = os.name
+
   case os[:family]
   when 'debian'
     describe http('localhost') do
@@ -45,11 +47,20 @@ control 'welcome-page' do
       its('body') { should cmp /Forbidden/ }
       its('body') { should cmp /Apache.* Server/ }
     end
+  when 'rhel'
+    describe http('localhost') do
+      its('status') { should eq 403 }
+      its('body') { should_not cmp /Forbidden/ }
+      if os_name == 'amazon'
+        its('body') { should cmp /It works!/ }
+      else
+        its('body') { should cmp /Powered by (CentOS|Alma|Rocky|Fedora|Apache)/ }
+      end
+    end
   else
     describe http('localhost') do
       its('status') { should eq 403 }
       its('body') { should_not cmp /Forbidden/ }
-      its('body') { should cmp /Powered by (CentOS|Alma|Rocky|Fedora|Apache)/ }
     end
   end
 end

--- a/test/integration/mod_auth_cas/controls/default.rb
+++ b/test/integration/mod_auth_cas/controls/default.rb
@@ -2,19 +2,21 @@ include_controls 'apache2-integration-tests' do
   skip_control 'welcome-page'
 end
 
-os_family = os.family
+httpd_command =
+  case os.family
+  when 'fedora', 'amazon'
+    'httpd -M'
+  when 'redhat'
+    os.release.to_i >= 9 ? 'httpd -M' : 'apachectl -M'
+  else
+    'apachectl -M'
+  end
 
 control 'auth_cas module enabled & running' do
   impact 1
   desc 'auth_cas module should be enabled with config'
 
-  if os_family == 'fedora'
-    describe command('httpd -M') do
-      its('stdout') { should match(/auth_cas/) }
-    end
-  else
-    describe command('apachectl -M') do
-      its('stdout') { should match(/auth_cas/) }
-    end
+  describe command httpd_command do
+    its('stdout') { should match(/auth_cas/) }
   end
 end

--- a/test/integration/mod_wsgi/controls/default.rb
+++ b/test/integration/mod_wsgi/controls/default.rb
@@ -2,20 +2,22 @@ include_controls 'apache2-integration-tests' do
   skip_control 'welcome-page'
 end
 
-os_family = os.family
+httpd_command =
+  case os.family
+  when 'fedora'
+    'httpd -M'
+  when 'redhat'
+    os.release.to_i >= 9 ? 'httpd -M' : 'apachectl -M'
+  else
+    'apachectl -M'
+  end
 
 control 'WSGI module enabled & running' do
   impact 1
   desc 'wsgi module should be enabled with config'
 
-  if os_family == 'fedora'
-    describe command('httpd -M') do
-      its('stdout') { should match(/wsgi_module/) }
-    end
-  else
-    describe command('apachectl -M') do
-      its('stdout') { should match(/wsgi_module/) }
-    end
+  describe command httpd_command do
+    its('stdout') { should match(/wsgi_module/) }
   end
 
   describe http('localhost') do


### PR DESCRIPTION
- *Breaking Change:* Create `apache2_service` resource for managing the Apache service and remove all internal references to reloading `service[apache2]`.
- Update to modern platforms
  - *Breaking Change:* Remove Amazon Linux 2
  - Add Amazon Linux 2023, EL9, Debian 12 and Ubuntu 22.04
- Deprecate `apache2_mod_php` for EL9, Fedora and Amazon Linux
- Deprecate `apache2_mod_wsgi` for Amazon Linux

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
