### PR TITLE
Fix issue when using apache2_mod_ssl resource instead a wrapper resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- Fix issue when using apache2_mod_ssl resource instead a wrapper resource
+
 ## 9.0.5 - *2023-09-28*
 
 ## 9.0.4 - *2023-09-04*

--- a/resources/mod_ssl.rb
+++ b/resources/mod_ssl.rb
@@ -61,11 +61,9 @@ property :directives, Hash,
 
 action :create do
   if platform_family?('rhel', 'fedora', 'suse', 'amazon')
-    with_run_context :root do
-      package new_resource.mod_ssl_pkg do
-        notifies :run, 'execute[generate-module-list]', :immediately
-        only_if { platform_family?('rhel', 'fedora', 'amazon') }
-      end
+    package new_resource.mod_ssl_pkg do
+      notifies :run, 'execute[generate-module-list]', :immediately
+      only_if { platform_family?('rhel', 'fedora', 'amazon') }
     end
   end
 


### PR DESCRIPTION
When doing `apache2_module 'ssl'` instead of another custom resource, the
mod_ssl package does not get installed properly due to the fact it's set to run
in the root context of the chef run. However, it never seems to get installed,
or at least installed in time for it to work leaving a system in a broken state.

I cannot see why this was needed in the first place as it seems to work without
it.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
