### PR TITLE
Match lock directory permissions and ownership to distribution for RHEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the apache2 cookbook.
 
 ## Unreleased
 
+- Match lock directory permissions and ownership to distribution for RHEL
+
 ## 9.2.0 - *2023-11-01*
 
 - Change InSpec test names and include the default profile in more places

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -250,13 +250,20 @@ action :install do
   end
 
   directory lock_dir do
-    mode '0750'
-    if platform_family?('debian')
+    case node['platform_family']
+    when 'debian'
+      mode '0750'
       owner new_resource.apache_user
-    else
+      group new_resource.root_group
+    when 'rhel', 'fedora', 'amazon'
+      mode '0710'
       owner 'root'
+      group new_resource.apache_group
+    else
+      mode '0750'
+      owner 'root'
+      group new_resource.root_group
     end
-    group new_resource.root_group
   end
 
   template "/etc/sysconfig/#{apache_platform_service_name}" do


### PR DESCRIPTION
This primarily fixes the permissions on RHEL-based systems to match what they
have by default. In some situations, this was leading to an idempotency issues
on RHEL systems. To work around this, setting the correct permission and
ownership works around this from happening.

It appears this permission/ownership was taken from a Debian-based system which
is why this was happening.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
