### PR TITLE
feat: fix EL httpd log/cache dir idempotency vs systemd-tmpfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,5 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration]
     steps:
-      - run: echo '${{ toJSON(needs.integration.outputs) }}'
+      - run: |
+          echo "Integration result: ${{ needs.integration.result }}"

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -167,7 +167,9 @@ action :install do
   end
 
   directory new_resource.log_dir do
-    mode '0750'
+    # On EL match the httpd package's tmpfiles.d mode (0700 root:root) so
+    # systemd-tmpfiles doesn't revert it between converges. See cache_dir below.
+    mode platform_family?('rhel', 'fedora', 'amazon') ? '0700' : '0750'
     recursive true
   end
 
@@ -229,9 +231,20 @@ action :install do
   end
 
   directory cache_dir do
-    mode '0755'
-    owner 'root'
-    group new_resource.root_group
+    # EL's httpd package ships /usr/lib/tmpfiles.d/httpd.conf, which
+    # systemd-tmpfiles re-applies at boot and during every httpd package
+    # transaction. Match its 0700 apache:apache mode here so the two don't fight
+    # and a second converge stays idempotent (this is also the layout that lets
+    # the apache worker own its cache tree).
+    if platform_family?('rhel', 'fedora', 'amazon')
+      mode '0700'
+      owner new_resource.apache_user
+      group new_resource.apache_group
+    else
+      mode '0755'
+      owner 'root'
+      group new_resource.root_group
+    end
   end
 
   directory lock_dir do

--- a/spec/resources/install_spec.rb
+++ b/spec/resources/install_spec.rb
@@ -103,5 +103,42 @@ describe 'apache2_install' do
       is_expected.to render_file('/etc/apache2/envvars')
         .with_content(/FOO=bar/)
     end
+
+    it 'creates the log and cache dirs with the Debian cookbook modes' do
+      is_expected.to create_directory('/var/log/apache2').with(mode: '0750')
+      is_expected.to create_directory('/var/cache/apache2').with(
+        mode: '0755',
+        owner: 'root',
+        group: 'root'
+      )
+    end
+  end
+end
+
+describe 'apache2_install on EL' do
+  step_into :apache2_install, :apache2_config
+  platform 'redhat', '9'
+
+  before do
+    stub_command('/usr/sbin/apachectl -t').and_return('foo')
+  end
+
+  recipe do
+    apache2_install 'package'
+  end
+
+  # The EL httpd package's /usr/lib/tmpfiles.d/httpd.conf enforces these modes at
+  # boot and on every package transaction; matching them here keeps a second
+  # converge idempotent instead of fighting systemd-tmpfiles.
+  it 'creates the log dir matching the vendor tmpfiles mode' do
+    is_expected.to create_directory('/var/log/httpd').with(mode: '0700')
+  end
+
+  it 'creates the cache dir matching the vendor tmpfiles mode and ownership' do
+    is_expected.to create_directory('/var/cache/httpd').with(
+      mode: '0700',
+      owner: 'apache',
+      group: 'apache'
+    )
   end
 end

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -84,6 +84,35 @@ control 'secure tuned defaults' do
   end
 end
 
+control 'httpd tmpfiles idempotency' do
+  impact 1
+  desc 'On EL the log/cache dir modes match the vendor tmpfiles.d so they survive a systemd-tmpfiles --create instead of flip-flopping between converges'
+
+  only_if('EL-only; Debian/SUSE ship no conflicting tmpfiles entry') do
+    %w(redhat fedora amazon).include?(os[:family])
+  end
+
+  # Re-stamp tmpfiles the way boot or a package transaction would; with the
+  # cookbook matching the vendor modes this is a no-op rather than a revert.
+  describe command('systemd-tmpfiles --create httpd.conf') do
+    its('exit_status') { should eq 0 }
+  end
+
+  describe file('/var/log/httpd') do
+    it { should be_directory }
+    it { should be_owned_by 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0700' }
+  end
+
+  describe file('/var/cache/httpd') do
+    it { should be_directory }
+    it { should be_owned_by 'apache' }
+    its('group') { should eq 'apache' }
+    its('mode') { should cmp '0700' }
+  end
+end
+
 control 'pid file' do
   apache_dir = case os[:family]
                when 'debian', 'suse'


### PR DESCRIPTION
This primarily fixes an idempotency issue on RHEL/Fedora/Amazon where a
second converge always reported directory[/var/log/httpd] and
directory[/var/cache/httpd] as updated (failing the
client_no_updated_resources Test Kitchen check).

The httpd package ships /usr/lib/tmpfiles.d/httpd.conf, which
systemd-tmpfiles re-applies at boot and during every httpd package
transaction. Its modes for /var/log/httpd (0700 root:root) and
/var/cache/httpd (0700 apache:apache) differed from the ones
apache2_install enforced (0750 and 0755 root:root), so the two
perpetually fought and the dirs never settled.

Match the vendor modes on EL so the directory resources agree with
systemd-tmpfiles instead of reverting each other. This is also the layout
the platform intends: 0700 apache:apache lets the apache worker own its
cache tree. Debian/SUSE/FreeBSD/Arch are unchanged (no conflicting
tmpfiles entry there).

Behavior change for EL users: /var/cache/httpd ownership moves from
root:root to apache:apache and both dirs tighten to 0700.

Also applies pending cookstyle autocorrections (line-continuation
spacing, concat -> push, hash argument alignment).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
