### PR TITLE
fix: use yum-epel resource for auth_cas

### DIFF
--- a/resources/mod_auth_cas.rb
+++ b/resources/mod_auth_cas.rb
@@ -86,7 +86,7 @@ action :install do
     when 'debian'
       package 'libapache2-mod-auth-cas'
     when 'rhel', 'fedora', 'amazon'
-      include_recipe 'yum-epel' unless platform_family?('fedora')
+      yum_epel 'default' unless platform_family?('fedora')
 
       package 'mod_auth_cas' do
         notifies :run, 'execute[generate-module-list]', :immediately

--- a/spec/libraries/mod_auth_cas_spec.rb
+++ b/spec/libraries/mod_auth_cas_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe Apache2::Cookbook::Helpers do
       it { expect(subject.apache_mod_auth_cas_install_method).to eq 'source' }
     end
 
+    context 'fedora' do
+      let(:platform_family) { 'fedora' }
+      let(:platform_version) { '42' }
+      it { expect(subject.apache_mod_auth_cas_install_method).to eq 'source' }
+    end
+
     context 'suse' do
       let(:platform_family) { 'suse' }
       let(:platform_version) { '15.1' }

--- a/spec/resources/mod_auth_cas_spec.rb
+++ b/spec/resources/mod_auth_cas_spec.rb
@@ -15,6 +15,7 @@ describe 'apache2_mod_auth_cas' do
 
     apache2_mod_auth_cas 'default' do
       directives(CASDebug: 'Off')
+      install_method 'package'
     end
   end
   context 'ubuntu' do
@@ -56,5 +57,27 @@ describe 'apache2_mod_auth_cas' do
     ].each do |line|
       it { is_expected.to render_file('/etc/apache2/mods-available/auth_cas.conf').with_content(line) }
     end
+  end
+
+  context 'rocky 9 package install' do
+    platform 'rocky', '9'
+
+    it { is_expected.to create_yum_epel('default') }
+    it { is_expected.to install_package('mod_auth_cas') }
+
+    it 'enables EPEL before installing mod_auth_cas' do
+      resources = chef_run.resource_collection.all_resources
+      epel = chef_run.find_resource(:yum_epel, 'default')
+      package = chef_run.find_resource(:package, 'mod_auth_cas')
+
+      expect(resources.index(epel)).to be < resources.index(package)
+    end
+  end
+
+  context 'fedora package install' do
+    platform 'fedora', '32'
+
+    it { is_expected.to install_package('mod_auth_cas') }
+    it { is_expected.not_to create_yum_epel('default') }
   end
 end

--- a/test/cookbooks/test/recipes/auth_cas.rb
+++ b/test/cookbooks/test/recipes/auth_cas.rb
@@ -8,7 +8,8 @@ apache2_install 'default' do
 end
 
 apache2_mod_auth_cas 'default' do
-  install_method 'package'
+  # Exercise the EPEL package path on RHEL; SUSE uses its supported source default.
+  install_method 'package' if platform_family?('rhel')
   directives(
     'CASCookiePath' => "#{cache_dir}/mod_auth_cas/"
   )

--- a/test/cookbooks/test/recipes/auth_cas.rb
+++ b/test/cookbooks/test/recipes/auth_cas.rb
@@ -8,6 +8,7 @@ apache2_install 'default' do
 end
 
 apache2_mod_auth_cas 'default' do
+  install_method 'package'
   directives(
     'CASCookiePath' => "#{cache_dir}/mod_auth_cas/"
   )


### PR DESCRIPTION
## Summary

* replace the removed `yum-epel` recipe include with the `yum_epel` custom resource
* keep Fedora exempt and preserve existing source-install defaults
* exercise the Rocky Linux 9 package-install path in ChefSpec and Kitchen

Closes #963.

## Verification

* `chef install Policyfile.rb`
* `cookstyle` (104 files, no offenses)
* ChefSpec (257 examples, 0 failures)
* `KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test mod-auth-cas-rockylinux-9 --destroy=always`
* second converge: 0/147 resources updated; InSpec passed
* independent spec and quality review: passed with no findings
